### PR TITLE
Upgrade to Triton-VM 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ default-features = false
 features = ["precommit-hook", "run-cargo-clippy", "run-cargo-fmt"]
 
 [dependencies]
-triton-vm = { git = "https://github.com/TritonVM/triton-vm.git", branch = "prerelease-0.15.0" }
-triton-opcodes = { version = "0.14", git = "https://github.com/TritonVM/triton-vm.git", branch = "master" }
-twenty-first = "0.14.1"
+triton-vm = "0.18.0"
+triton-opcodes = "0.18.0"
+twenty-first = "0.18.0"
 rand = "0.8.5"
 itertools = "0.10.5"
 num = "0.4.0"

--- a/benchmarks/tasm_arithmetic_u64_div2.json
+++ b/benchmarks/tasm_arithmetic_u64_div2.json
@@ -3,7 +3,7 @@
     "name": "tasm_arithmetic_u64_div2",
     "processor_table_height": 16,
     "hash_table_height": 0,
-    "u32_table_height": 40,
+    "u32_table_height": 37,
     "case": "CommonCase"
   },
   {

--- a/benchmarks/tasm_arithmetic_u64_index_of_last_nonzero_bit.json
+++ b/benchmarks/tasm_arithmetic_u64_index_of_last_nonzero_bit.json
@@ -3,7 +3,7 @@
     "name": "tasm_arithmetic_u64_index_of_last_nonzero_bit",
     "processor_table_height": 38,
     "hash_table_height": 0,
-    "u32_table_height": 165,
+    "u32_table_height": 132,
     "case": "CommonCase"
   },
   {

--- a/benchmarks/tasm_hashing_load_auth_path_from_secret_in_safe_list.json
+++ b/benchmarks/tasm_hashing_load_auth_path_from_secret_in_safe_list.json
@@ -1,14 +1,14 @@
 [
   {
     "name": "tasm_hashing_load_auth_path_from_secret_in_safe_list",
-    "processor_table_height": 2070,
+    "processor_table_height": 1842,
     "hash_table_height": 0,
     "u32_table_height": 264,
     "case": "CommonCase"
   },
   {
     "name": "tasm_hashing_load_auth_path_from_secret_in_safe_list",
-    "processor_table_height": 4086,
+    "processor_table_height": 3634,
     "hash_table_height": 0,
     "u32_table_height": 520,
     "case": "WorstCase"

--- a/benchmarks/tasm_hashing_load_auth_path_from_secret_in_unsafe_list.json
+++ b/benchmarks/tasm_hashing_load_auth_path_from_secret_in_unsafe_list.json
@@ -1,14 +1,14 @@
 [
   {
     "name": "tasm_hashing_load_auth_path_from_secret_in_unsafe_list",
-    "processor_table_height": 1752,
+    "processor_table_height": 1559,
     "hash_table_height": 0,
     "u32_table_height": 8,
     "case": "CommonCase"
   },
   {
     "name": "tasm_hashing_load_auth_path_from_secret_in_unsafe_list",
-    "processor_table_height": 3480,
+    "processor_table_height": 3095,
     "hash_table_height": 0,
     "u32_table_height": 8,
     "case": "WorstCase"

--- a/benchmarks/tasm_hashing_load_auth_path_from_std_in_safe_list.json
+++ b/benchmarks/tasm_hashing_load_auth_path_from_std_in_safe_list.json
@@ -1,14 +1,14 @@
 [
   {
     "name": "tasm_hashing_load_auth_path_from_std_in_safe_list",
-    "processor_table_height": 2066,
+    "processor_table_height": 1838,
     "hash_table_height": 0,
     "u32_table_height": 256,
     "case": "CommonCase"
   },
   {
     "name": "tasm_hashing_load_auth_path_from_std_in_safe_list",
-    "processor_table_height": 4082,
+    "processor_table_height": 3630,
     "hash_table_height": 0,
     "u32_table_height": 512,
     "case": "WorstCase"

--- a/benchmarks/tasm_hashing_load_auth_path_from_std_in_unsafe_list.json
+++ b/benchmarks/tasm_hashing_load_auth_path_from_std_in_unsafe_list.json
@@ -1,14 +1,14 @@
 [
   {
     "name": "tasm_hashing_load_auth_path_from_std_in_unsafe_list",
-    "processor_table_height": 1748,
+    "processor_table_height": 1555,
     "hash_table_height": 0,
     "u32_table_height": 0,
     "case": "CommonCase"
   },
   {
     "name": "tasm_hashing_load_auth_path_from_std_in_unsafe_list",
-    "processor_table_height": 3476,
+    "processor_table_height": 3091,
     "hash_table_height": 0,
     "u32_table_height": 0,
     "case": "WorstCase"

--- a/benchmarks/tasm_list_safe_u32_get_element_digest.json
+++ b/benchmarks/tasm_list_safe_u32_get_element_digest.json
@@ -1,14 +1,14 @@
 [
   {
     "name": "tasm_list_safe_u32_get_element_digest",
-    "processor_table_height": 41,
+    "processor_table_height": 35,
     "hash_table_height": 0,
     "u32_table_height": 7,
     "case": "CommonCase"
   },
   {
     "name": "tasm_list_safe_u32_get_element_digest",
-    "processor_table_height": 41,
+    "processor_table_height": 35,
     "hash_table_height": 0,
     "u32_table_height": 8,
     "case": "WorstCase"

--- a/benchmarks/tasm_list_safe_u32_length_digest.json
+++ b/benchmarks/tasm_list_safe_u32_length_digest.json
@@ -1,14 +1,14 @@
 [
   {
     "name": "tasm_list_safe_u32_length_digest",
-    "processor_table_height": 7,
+    "processor_table_height": 6,
     "hash_table_height": 0,
     "u32_table_height": 0,
     "case": "CommonCase"
   },
   {
     "name": "tasm_list_safe_u32_length_digest",
-    "processor_table_height": 7,
+    "processor_table_height": 6,
     "hash_table_height": 0,
     "u32_table_height": 0,
     "case": "WorstCase"

--- a/benchmarks/tasm_list_safe_u32_new_digest.json
+++ b/benchmarks/tasm_list_safe_u32_new_digest.json
@@ -1,14 +1,14 @@
 [
   {
     "name": "tasm_list_safe_u32_new_digest",
-    "processor_table_height": 36,
+    "processor_table_height": 32,
     "hash_table_height": 0,
     "u32_table_height": 0,
     "case": "CommonCase"
   },
   {
     "name": "tasm_list_safe_u32_new_digest",
-    "processor_table_height": 36,
+    "processor_table_height": 32,
     "hash_table_height": 0,
     "u32_table_height": 0,
     "case": "WorstCase"

--- a/benchmarks/tasm_list_safe_u32_pop_digest.json
+++ b/benchmarks/tasm_list_safe_u32_pop_digest.json
@@ -1,14 +1,14 @@
 [
   {
     "name": "tasm_list_safe_u32_pop_digest",
-    "processor_table_height": 45,
+    "processor_table_height": 40,
     "hash_table_height": 0,
     "u32_table_height": 0,
     "case": "CommonCase"
   },
   {
     "name": "tasm_list_safe_u32_pop_digest",
-    "processor_table_height": 45,
+    "processor_table_height": 40,
     "hash_table_height": 0,
     "u32_table_height": 0,
     "case": "WorstCase"

--- a/benchmarks/tasm_list_safe_u32_push_digest.json
+++ b/benchmarks/tasm_list_safe_u32_push_digest.json
@@ -1,14 +1,14 @@
 [
   {
     "name": "tasm_list_safe_u32_push_digest",
-    "processor_table_height": 49,
+    "processor_table_height": 42,
     "hash_table_height": 0,
     "u32_table_height": 11,
     "case": "CommonCase"
   },
   {
     "name": "tasm_list_safe_u32_push_digest",
-    "processor_table_height": 49,
+    "processor_table_height": 42,
     "hash_table_height": 0,
     "u32_table_height": 11,
     "case": "WorstCase"

--- a/benchmarks/tasm_list_safe_u32_set_element_digest.json
+++ b/benchmarks/tasm_list_safe_u32_set_element_digest.json
@@ -1,14 +1,14 @@
 [
   {
     "name": "tasm_list_safe_u32_set_element_digest",
-    "processor_table_height": 39,
+    "processor_table_height": 33,
     "hash_table_height": 0,
     "u32_table_height": 7,
     "case": "CommonCase"
   },
   {
     "name": "tasm_list_safe_u32_set_element_digest",
-    "processor_table_height": 39,
+    "processor_table_height": 33,
     "hash_table_height": 0,
     "u32_table_height": 8,
     "case": "WorstCase"

--- a/benchmarks/tasm_list_safe_u32_set_length_digest.json
+++ b/benchmarks/tasm_list_safe_u32_set_length_digest.json
@@ -1,14 +1,14 @@
 [
   {
     "name": "tasm_list_safe_u32_set_length_digest",
-    "processor_table_height": 17,
+    "processor_table_height": 15,
     "hash_table_height": 0,
     "u32_table_height": 11,
     "case": "CommonCase"
   },
   {
     "name": "tasm_list_safe_u32_set_length_digest",
-    "processor_table_height": 17,
+    "processor_table_height": 15,
     "hash_table_height": 0,
     "u32_table_height": 11,
     "case": "WorstCase"

--- a/benchmarks/tasm_list_unsafe_u32_get_element_digest.json
+++ b/benchmarks/tasm_list_unsafe_u32_get_element_digest.json
@@ -1,14 +1,14 @@
 [
   {
     "name": "tasm_list_unsafe_u32_get_element_digest",
-    "processor_table_height": 32,
+    "processor_table_height": 27,
     "hash_table_height": 0,
     "u32_table_height": 0,
     "case": "CommonCase"
   },
   {
     "name": "tasm_list_unsafe_u32_get_element_digest",
-    "processor_table_height": 32,
+    "processor_table_height": 27,
     "hash_table_height": 0,
     "u32_table_height": 0,
     "case": "WorstCase"

--- a/benchmarks/tasm_list_unsafe_u32_length_long_digest.json
+++ b/benchmarks/tasm_list_unsafe_u32_length_long_digest.json
@@ -1,14 +1,14 @@
 [
   {
     "name": "tasm_list_unsafe_u32_length_long_digest",
-    "processor_table_height": 7,
+    "processor_table_height": 6,
     "hash_table_height": 0,
     "u32_table_height": 0,
     "case": "CommonCase"
   },
   {
     "name": "tasm_list_unsafe_u32_length_long_digest",
-    "processor_table_height": 7,
+    "processor_table_height": 6,
     "hash_table_height": 0,
     "u32_table_height": 0,
     "case": "WorstCase"

--- a/benchmarks/tasm_list_unsafe_u32_new_digest.json
+++ b/benchmarks/tasm_list_unsafe_u32_new_digest.json
@@ -1,14 +1,14 @@
 [
   {
     "name": "tasm_list_unsafe_u32_new_digest",
-    "processor_table_height": 7,
+    "processor_table_height": 6,
     "hash_table_height": 0,
     "u32_table_height": 0,
     "case": "CommonCase"
   },
   {
     "name": "tasm_list_unsafe_u32_new_digest",
-    "processor_table_height": 7,
+    "processor_table_height": 6,
     "hash_table_height": 0,
     "u32_table_height": 0,
     "case": "WorstCase"

--- a/benchmarks/tasm_list_unsafe_u32_pop_digest.json
+++ b/benchmarks/tasm_list_unsafe_u32_pop_digest.json
@@ -1,14 +1,14 @@
 [
   {
     "name": "tasm_list_unsafe_u32_pop_digest",
-    "processor_table_height": 43,
+    "processor_table_height": 38,
     "hash_table_height": 0,
     "u32_table_height": 0,
     "case": "CommonCase"
   },
   {
     "name": "tasm_list_unsafe_u32_pop_digest",
-    "processor_table_height": 43,
+    "processor_table_height": 38,
     "hash_table_height": 0,
     "u32_table_height": 0,
     "case": "WorstCase"

--- a/benchmarks/tasm_list_unsafe_u32_push_digest.json
+++ b/benchmarks/tasm_list_unsafe_u32_push_digest.json
@@ -1,14 +1,14 @@
 [
   {
     "name": "tasm_list_unsafe_u32_push_digest",
-    "processor_table_height": 40,
+    "processor_table_height": 34,
     "hash_table_height": 0,
     "u32_table_height": 0,
     "case": "CommonCase"
   },
   {
     "name": "tasm_list_unsafe_u32_push_digest",
-    "processor_table_height": 40,
+    "processor_table_height": 34,
     "hash_table_height": 0,
     "u32_table_height": 0,
     "case": "WorstCase"

--- a/benchmarks/tasm_list_unsafe_u32_set_element_digest.json
+++ b/benchmarks/tasm_list_unsafe_u32_set_element_digest.json
@@ -1,14 +1,14 @@
 [
   {
     "name": "tasm_list_unsafe_u32_set_element_digest",
-    "processor_table_height": 32,
+    "processor_table_height": 27,
     "hash_table_height": 0,
     "u32_table_height": 0,
     "case": "CommonCase"
   },
   {
     "name": "tasm_list_unsafe_u32_set_element_digest",
-    "processor_table_height": 32,
+    "processor_table_height": 27,
     "hash_table_height": 0,
     "u32_table_height": 0,
     "case": "WorstCase"

--- a/benchmarks/tasm_list_unsafe_u32_set_length_digest.json
+++ b/benchmarks/tasm_list_unsafe_u32_set_length_digest.json
@@ -1,14 +1,14 @@
 [
   {
     "name": "tasm_list_unsafe_u32_set_length_digest",
-    "processor_table_height": 5,
+    "processor_table_height": 4,
     "hash_table_height": 0,
     "u32_table_height": 0,
     "case": "CommonCase"
   },
   {
     "name": "tasm_list_unsafe_u32_set_length_digest",
-    "processor_table_height": 5,
+    "processor_table_height": 4,
     "hash_table_height": 0,
     "u32_table_height": 0,
     "case": "WorstCase"

--- a/benchmarks/tasm_mmr_calculate_new_peaks_from_append.json
+++ b/benchmarks/tasm_mmr_calculate_new_peaks_from_append.json
@@ -1,15 +1,15 @@
 [
   {
     "name": "tasm_mmr_calculate_new_peaks_from_append",
-    "processor_table_height": 5758,
-    "hash_table_height": 270,
-    "u32_table_height": 164,
+    "processor_table_height": 5091,
+    "hash_table_height": 180,
+    "u32_table_height": 131,
     "case": "CommonCase"
   },
   {
     "name": "tasm_mmr_calculate_new_peaks_from_append",
-    "processor_table_height": 11803,
-    "hash_table_height": 558,
+    "processor_table_height": 10432,
+    "hash_table_height": 372,
     "u32_table_height": 132,
     "case": "WorstCase"
   }

--- a/benchmarks/tasm_mmr_calculate_new_peaks_from_leaf_mutation.json
+++ b/benchmarks/tasm_mmr_calculate_new_peaks_from_leaf_mutation.json
@@ -1,16 +1,16 @@
 [
   {
     "name": "tasm_mmr_calculate_new_peaks_from_leaf_mutation",
-    "processor_table_height": 3138,
-    "hash_table_height": 279,
-    "u32_table_height": 1705,
+    "processor_table_height": 2978,
+    "hash_table_height": 186,
+    "u32_table_height": 803,
     "case": "CommonCase"
   },
   {
     "name": "tasm_mmr_calculate_new_peaks_from_leaf_mutation",
-    "processor_table_height": 6109,
-    "hash_table_height": 567,
-    "u32_table_height": 4762,
+    "processor_table_height": 5789,
+    "hash_table_height": 378,
+    "u32_table_height": 1101,
     "case": "WorstCase"
   }
 ]

--- a/benchmarks/tasm_mmr_data_index_to_node_index.json
+++ b/benchmarks/tasm_mmr_data_index_to_node_index.json
@@ -3,14 +3,14 @@
     "name": "tasm_mmr_data_index_to_node_index",
     "processor_table_height": 2627,
     "hash_table_height": 0,
-    "u32_table_height": 2470,
+    "u32_table_height": 2396,
     "case": "CommonCase"
   },
   {
     "name": "tasm_mmr_data_index_to_node_index",
     "processor_table_height": 5701,
     "hash_table_height": 0,
-    "u32_table_height": 7801,
+    "u32_table_height": 5776,
     "case": "WorstCase"
   }
 ]

--- a/benchmarks/tasm_mmr_leaf_index_to_mt_index_and_peak_index.json
+++ b/benchmarks/tasm_mmr_leaf_index_to_mt_index_and_peak_index.json
@@ -3,14 +3,14 @@
     "name": "tasm_mmr_leaf_index_to_mt_index_and_peak_index",
     "processor_table_height": 245,
     "hash_table_height": 0,
-    "u32_table_height": 342,
+    "u32_table_height": 339,
     "case": "CommonCase"
   },
   {
     "name": "tasm_mmr_leaf_index_to_mt_index_and_peak_index",
     "processor_table_height": 3061,
     "hash_table_height": 0,
-    "u32_table_height": 3997,
+    "u32_table_height": 2208,
     "case": "WorstCase"
   }
 ]

--- a/benchmarks/tasm_mmr_left_child.json
+++ b/benchmarks/tasm_mmr_left_child.json
@@ -3,14 +3,14 @@
     "name": "tasm_mmr_left_child",
     "processor_table_height": 50,
     "hash_table_height": 0,
-    "u32_table_height": 39,
+    "u32_table_height": 37,
     "case": "CommonCase"
   },
   {
     "name": "tasm_mmr_left_child",
     "processor_table_height": 50,
     "hash_table_height": 0,
-    "u32_table_height": 70,
+    "u32_table_height": 68,
     "case": "WorstCase"
   }
 ]

--- a/benchmarks/tasm_mmr_non_leaf_nodes_left.json
+++ b/benchmarks/tasm_mmr_non_leaf_nodes_left.json
@@ -3,14 +3,14 @@
     "name": "tasm_mmr_non_leaf_nodes_left",
     "processor_table_height": 2502,
     "hash_table_height": 0,
-    "u32_table_height": 2296,
+    "u32_table_height": 2226,
     "case": "CommonCase"
   },
   {
     "name": "tasm_mmr_non_leaf_nodes_left",
     "processor_table_height": 5655,
     "hash_table_height": 0,
-    "u32_table_height": 7735,
+    "u32_table_height": 5710,
     "case": "WorstCase"
   }
 ]

--- a/benchmarks/tasm_mmr_right_child_and_height.json
+++ b/benchmarks/tasm_mmr_right_child_and_height.json
@@ -3,14 +3,14 @@
     "name": "tasm_mmr_right_child_and_height",
     "processor_table_height": 3288,
     "hash_table_height": 0,
-    "u32_table_height": 1953,
+    "u32_table_height": 1826,
     "case": "CommonCase"
   },
   {
     "name": "tasm_mmr_right_child_and_height",
     "processor_table_height": 6114,
     "hash_table_height": 0,
-    "u32_table_height": 7611,
+    "u32_table_height": 4634,
     "case": "WorstCase"
   }
 ]

--- a/benchmarks/tasm_mmr_right_lineage_count_and_own_height.json
+++ b/benchmarks/tasm_mmr_right_lineage_count_and_own_height.json
@@ -3,14 +3,14 @@
     "name": "tasm_mmr_right_lineage_count_and_own_height",
     "processor_table_height": 3255,
     "hash_table_height": 0,
-    "u32_table_height": 2868,
+    "u32_table_height": 2774,
     "case": "CommonCase"
   },
   {
     "name": "tasm_mmr_right_lineage_count_and_own_height",
     "processor_table_height": 6238,
     "hash_table_height": 0,
-    "u32_table_height": 7611,
+    "u32_table_height": 4634,
     "case": "WorstCase"
   }
 ]

--- a/benchmarks/tasm_mmr_right_lineage_length.json
+++ b/benchmarks/tasm_mmr_right_lineage_length.json
@@ -3,14 +3,14 @@
     "name": "tasm_mmr_right_lineage_length",
     "processor_table_height": 3906,
     "hash_table_height": 0,
-    "u32_table_height": 2781,
+    "u32_table_height": 2021,
     "case": "CommonCase"
   },
   {
     "name": "tasm_mmr_right_lineage_length",
     "processor_table_height": 8396,
     "hash_table_height": 0,
-    "u32_table_height": 7556,
+    "u32_table_height": 5997,
     "case": "WorstCase"
   }
 ]

--- a/benchmarks/tasm_mmr_verify_from_memory.json
+++ b/benchmarks/tasm_mmr_verify_from_memory.json
@@ -1,16 +1,16 @@
 [
   {
     "name": "tasm_mmr_verify_from_memory",
-    "processor_table_height": 3087,
-    "hash_table_height": 279,
-    "u32_table_height": 1705,
+    "processor_table_height": 2927,
+    "hash_table_height": 186,
+    "u32_table_height": 803,
     "case": "CommonCase"
   },
   {
     "name": "tasm_mmr_verify_from_memory",
-    "processor_table_height": 5951,
-    "hash_table_height": 558,
-    "u32_table_height": 4646,
+    "processor_table_height": 5636,
+    "hash_table_height": 372,
+    "u32_table_height": 896,
     "case": "WorstCase"
   }
 ]

--- a/benchmarks/tasm_mmr_verify_from_secret_in.json
+++ b/benchmarks/tasm_mmr_verify_from_secret_in.json
@@ -1,16 +1,16 @@
 [
   {
     "name": "tasm_mmr_verify_from_secret_in",
-    "processor_table_height": 2525,
-    "hash_table_height": 279,
-    "u32_table_height": 1705,
+    "processor_table_height": 2520,
+    "hash_table_height": 186,
+    "u32_table_height": 803,
     "case": "CommonCase"
   },
   {
     "name": "tasm_mmr_verify_from_secret_in",
-    "processor_table_height": 4937,
-    "hash_table_height": 567,
-    "u32_table_height": 2690,
+    "processor_table_height": 4932,
+    "hash_table_height": 378,
+    "u32_table_height": 831,
     "case": "WorstCase"
   }
 ]

--- a/benchmarks/tasm_mmr_verify_load_from_secret_in.json
+++ b/benchmarks/tasm_mmr_verify_load_from_secret_in.json
@@ -1,16 +1,16 @@
 [
   {
     "name": "tasm_mmr_verify_load_from_secret_in",
-    "processor_table_height": 1181,
-    "hash_table_height": 54,
-    "u32_table_height": 209,
+    "processor_table_height": 1109,
+    "hash_table_height": 36,
+    "u32_table_height": 109,
     "case": "CommonCase"
   },
   {
     "name": "tasm_mmr_verify_load_from_secret_in",
-    "processor_table_height": 1780,
-    "hash_table_height": 90,
-    "u32_table_height": 367,
+    "processor_table_height": 1664,
+    "hash_table_height": 60,
+    "u32_table_height": 180,
     "case": "WorstCase"
   }
 ]

--- a/benchmarks/tasm_recufier_mt_ap_verify.json
+++ b/benchmarks/tasm_recufier_mt_ap_verify.json
@@ -1,15 +1,15 @@
 [
   {
     "name": "tasm_recufier_mt_ap_verify",
-    "processor_table_height": 681,
-    "hash_table_height": 378,
+    "processor_table_height": 665,
+    "hash_table_height": 252,
     "u32_table_height": 0,
     "case": "CommonCase"
   },
   {
     "name": "tasm_recufier_mt_ap_verify",
-    "processor_table_height": 975,
-    "hash_table_height": 756,
+    "processor_table_height": 959,
+    "hash_table_height": 504,
     "u32_table_height": 0,
     "case": "WorstCase"
   }

--- a/src/all_snippets.rs
+++ b/src/all_snippets.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use crate::{
     arithmetic::{
         u32::{
@@ -64,6 +66,7 @@ use crate::{
     pseudo::{lsb::Lsb, neg::Neg, sub::Sub},
     recufier::merkle_tree_ap_verify_from_secret_input::MtApVerifyFromSecretInput,
     snippet::{DataType, Snippet},
+    VmHasher,
 };
 
 pub fn name_to_snippet(fn_name: &str) -> Box<dyn Snippet> {
@@ -227,23 +230,23 @@ pub fn name_to_snippet(fn_name: &str) -> Box<dyn Snippet> {
         "tasm_list_unsafe_u32_set_length_digest" => Box::new(UnsafeSetLength(DataType::Digest)),
 
         // MMR
-        "tasm_mmr_calculate_new_peaks_from_append" => Box::new(CalculateNewPeaksFromAppend),
+        "tasm_mmr_calculate_new_peaks_from_append" => Box::new(CalculateNewPeaksFromAppend(PhantomData::<VmHasher>)),
         "tasm_mmr_calculate_new_peaks_from_leaf_mutation" => {
-            Box::new(MmrCalculateNewPeaksFromLeafMutationMtIndices)
+            Box::new(MmrCalculateNewPeaksFromLeafMutationMtIndices(PhantomData::<VmHasher>))
         }
         "tasm_mmr_data_index_to_node_index" => Box::new(DataIndexToNodeIndex),
         "tasm_mmr_get_height_from_leaf_index" => Box::new(GetHeightFromDataIndex),
         "tasm_mmr_leaf_index_to_mt_index_and_peak_index" => Box::new(MmrLeafIndexToMtIndexAndPeakIndex),
         "tasm_mmr_left_child" => Box::new(MmrLeftChild),
         "tasm_mmr_leftmost_ancestor" => Box::new(MmrLeftMostAncestor),
-        "tasm_mmr_verify_load_from_secret_in" => Box::new(MmrLoadFromSecretInThenVerify),
+        "tasm_mmr_verify_load_from_secret_in" => Box::new(MmrLoadFromSecretInThenVerify(PhantomData::<VmHasher>)),
         "tasm_mmr_non_leaf_nodes_left" => Box::new(MmrNonLeafNodesLeftUsingAnd),
         "tasm_mmr_right_child_and_height" => Box::new(MmrRightChildAndHeight),
         "tasm_mmr_right_child" => Box::new(MmrRightChild),
         "tasm_mmr_right_lineage_count_and_own_height" => Box::new(MmrRightLineageCountAndHeight),
         "tasm_mmr_right_lineage_length" => Box::new(MmrRightLineageLength),
-        "tasm_mmr_verify_from_memory" => Box::new(MmrVerifyFromMemory),
-        "tasm_mmr_verify_from_secret_in" => Box::new(MmrVerifyLeafMembershipFromSecretIn),
+        "tasm_mmr_verify_from_memory" => Box::new(MmrVerifyFromMemory(PhantomData::<VmHasher>)),
+        "tasm_mmr_verify_from_secret_in" => Box::new(MmrVerifyLeafMembershipFromSecretIn(PhantomData::<VmHasher>)),
 
         // other
         "tasm_other_bfe_add" => Box::new(BfeAdd),
@@ -254,7 +257,7 @@ pub fn name_to_snippet(fn_name: &str) -> Box<dyn Snippet> {
         "tasm_pseudo_sub" => Box::new(Sub),
 
         // recufy
-        "tasm_recufier_mt_ap_verify" => Box::new(MtApVerifyFromSecretInput),
+        "tasm_recufier_mt_ap_verify" => Box::new(MtApVerifyFromSecretInput(PhantomData::<VmHasher>)),
 
         // dyn_malloc
         "dyn_malloc" => Box::new(DynMalloc),

--- a/src/dyn_malloc.rs
+++ b/src/dyn_malloc.rs
@@ -57,7 +57,6 @@ impl Snippet for DynMalloc {
             // After: _ *next_addr
             {entrypoint}:
                 push {free_pointer_addr}  // _ size *free_pointer
-                push 0                    // _ size *free_pointer 0
                 read_mem                  // _ size *free_pointer *next_addr'
 
                 // add 1 iff `next_addr` was 0, i.e. uninitialized.
@@ -73,7 +72,7 @@ impl Snippet for DynMalloc {
                 swap3                     // _ *next_addr *free_pointer *(next_addr + size) size
                 pop                       // _ *next_addr *free_pointer *(next_addr + size)
                 write_mem
-                pop pop                   // _ next_addr
+                pop                       // _ next_addr
                 return
             "
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use triton_opcodes::program::Program;
 use triton_vm::table::master_table::MasterBaseTable;
 use triton_vm::vm;
+use twenty_first::shared_math::tip5::{self, Tip5};
 
 use triton_vm::op_stack::OP_STACK_REG_COUNT;
 use triton_vm::vm::VMState;
@@ -25,6 +26,11 @@ pub mod rust_shadowing_helper_functions;
 pub mod snippet;
 mod snippet_bencher;
 mod test_helpers;
+
+// The hasher type must match whatever algebraic hasher the VM is using
+pub type VmHasher = Tip5;
+pub type Digest = tip5::Digest;
+pub const DIGEST_LENGTH: usize = tip5::DIGEST_LENGTH;
 
 #[derive(Clone, Debug)]
 pub struct ExecutionState {
@@ -106,7 +112,6 @@ pub fn execute(
         executed_code.push_str("write_mem\n");
 
         // Clean stack after writing to memory
-        executed_code.push_str("pop\n");
         executed_code.push_str("pop\n");
     }
 

--- a/src/list/safe_u32/length.rs
+++ b/src/list/safe_u32/length.rs
@@ -92,7 +92,6 @@ impl Snippet for SafeLength {
         format!(
             "
             {entry_point}:
-                push 0
                 read_mem
                 swap1
                 pop

--- a/src/list/safe_u32/pop.rs
+++ b/src/list/safe_u32/pop.rs
@@ -56,9 +56,8 @@ impl Snippet for SafePop {
         let entry_point = self.entrypoint();
 
         let mut code_to_read_elements = String::default();
-        // Start and end at loop: Stack: _  [elems], address_for_last_unread_element
+        // Start and end of loop: Stack: _  [elems], address_for_last_unread_element
         for i in 0..self.0.get_size() {
-            code_to_read_elements.push_str("push 0\n");
             code_to_read_elements.push_str("read_mem\n");
             // stack: _  address_for_last_unread_element, elem_{{N - 1 - i}}
 
@@ -72,15 +71,22 @@ impl Snippet for SafePop {
         }
 
         let element_size = self.0.get_size();
+
+        // Code to multiply with size. If size is 1, do nothing to save two clock cycles.
+        let mul_with_size = if element_size != 1 {
+            format!("push {element_size}\n mul\n")
+        } else {
+            String::default()
+        };
         format!(
+            "
             // Before: _ *list
             // After: _ elem{{N - 1}}, elem{{N - 2}}, ..., elem{{0}}
-            "{entry_point}:
-                push 0
+            {entry_point}:
                 read_mem
                 // stack : _  *list, length
 
-                // Assert that length is over 0
+                // Assert that length is not 0
                 dup0
                 push 0
                 eq
@@ -90,18 +96,16 @@ impl Snippet for SafePop {
                 // stack : _  *list, length
 
                 // Decrease length value by one and write back to memory
+                swap1
+                dup1
                 push -1
                 add
                 write_mem
-                // stack : _  *list, length - 1
+                swap1
+                // stack : _ *list initial_length
 
-                push 1
-                add
-                // stack : _  *list, length
-
-                push {element_size}
-                mul
-                // stack : _  *list, offset_for_last_element = (N * initial_length)
+                {mul_with_size}
+                // stack : _  *list, (offset_for_last_element = (N * initial_length))
 
                 add
                 push 1

--- a/src/list/safe_u32/set.rs
+++ b/src/list/safe_u32/set.rs
@@ -79,13 +79,19 @@ impl Snippet for SafeSet {
         for i in 0..element_size {
             write_elements_to_memory_code.push_str("swap1\n");
             write_elements_to_memory_code.push_str("write_mem\n");
-            write_elements_to_memory_code.push_str("pop\n");
             if i != element_size - 1 {
                 // Prepare for next write. Not needed for last iteration.
                 write_elements_to_memory_code.push_str("push 1\n");
                 write_elements_to_memory_code.push_str("add\n");
             }
         }
+
+        // Code to multiply with size. If size is 1, do nothing to save two clock cycles.
+        let mul_with_size = if element_size != 1 {
+            format!("push {element_size}\n mul\n")
+        } else {
+            String::default()
+        };
 
         format!(
             "
@@ -94,7 +100,6 @@ impl Snippet for SafeSet {
                 {entrypoint}:
                     // Verify that index is less than length
                     swap1
-                    push 0
                     read_mem
                     // _ elem{{N - 1}}, elem{{N - 2}}, ..., elem{{0}} index *list length
 
@@ -107,8 +112,7 @@ impl Snippet for SafeSet {
                     swap1
                     // _ elem{{N - 1}}, elem{{N - 2}}, ..., elem{{0}} *list index
 
-                    push {element_size}
-                    mul
+                    {mul_with_size}
                     push 2
                     add
                     add

--- a/src/list/safe_u32/set_length.rs
+++ b/src/list/safe_u32/set_length.rs
@@ -80,7 +80,6 @@ impl Snippet for SafeSetLength {
                     dup2
                     push 1
                     add
-                    push 0
                     read_mem
                     // Stack: *list list_length list_length (*list + 1) capacity
 
@@ -97,9 +96,6 @@ impl Snippet for SafeSetLength {
                     // Stack: *list list_length
 
                     write_mem
-                    // Stack: *list list_length
-
-                    pop
                     // Stack: *list
 
                     return

--- a/src/list/unsafe_u32/get.rs
+++ b/src/list/unsafe_u32/get.rs
@@ -62,7 +62,6 @@ impl Snippet for UnsafeGet {
 
         // Start and end at loop: Stack: _  [elems], address_of_next_element
         for i in 0..self.0.get_size() {
-            code_to_read_elements.push_str("push 0\n");
             code_to_read_elements.push_str("read_mem\n");
             // stack: _  address_for_last_unread_element, elem_{{N - 1 - i}}
 
@@ -73,7 +72,14 @@ impl Snippet for UnsafeGet {
                 code_to_read_elements.push_str("add\n");
             }
         }
-        let size = self.0.get_size();
+        let element_size = self.0.get_size();
+
+        // Code to multiply with size. If size is 1, do nothing to save two clock cycles.
+        let mul_with_size = if element_size != 1 {
+            format!("push {element_size}\n mul\n")
+        } else {
+            String::default()
+        };
         format!(
             "
             // BEFORE: _ *list index
@@ -81,8 +87,7 @@ impl Snippet for UnsafeGet {
             {entrypoint}:
                 push 1
                 add
-                push {size}
-                mul
+                {mul_with_size}
                 // stack: _ *list (N * (index + 1))
 
                 add

--- a/src/list/unsafe_u32/length.rs
+++ b/src/list/unsafe_u32/length.rs
@@ -94,7 +94,6 @@ impl Snippet for UnsafeLengthLong {
         format!(
             "
             {entry_point}:
-                push 0
                 read_mem
                 swap1
                 pop
@@ -188,7 +187,6 @@ impl Snippet for UnsafeLengthShort {
         format!(
             "
             {entry_point}:
-                push 0
                 read_mem
                 return
                 "

--- a/src/list/unsafe_u32/new.rs
+++ b/src/list/unsafe_u32/new.rs
@@ -62,9 +62,6 @@ impl Snippet for UnsafeNew {
 
                     push 0
                     write_mem
-                    // _ *list 0
-
-                    pop
                     // _ *list
 
                     return

--- a/src/list/unsafe_u32/set.rs
+++ b/src/list/unsafe_u32/set.rs
@@ -69,7 +69,6 @@ impl Snippet for UnsafeSet {
         for i in 0..element_size {
             write_elements_to_memory_code.push_str("swap1\n");
             write_elements_to_memory_code.push_str("write_mem\n");
-            write_elements_to_memory_code.push_str("pop\n");
             if i != element_size - 1 {
                 // Prepare for next write. Not needed for last iteration.
                 write_elements_to_memory_code.push_str("push 1\n");
@@ -77,13 +76,17 @@ impl Snippet for UnsafeSet {
             }
         }
 
+        let mul_with_size = if element_size != 1 {
+            format!("push {element_size}\n mul\n")
+        } else {
+            String::default()
+        };
         format!(
             "
                 // BEFORE: _ elem{{N - 1}}, elem{{N - 2}}, ..., elem{{0}} *list index
                 // AFTER: _
                 {entrypoint}:
-                    push {element_size}
-                    mul
+                    {mul_with_size}
                     push 1
                     add
                     add

--- a/src/list/unsafe_u32/set_length.rs
+++ b/src/list/unsafe_u32/set_length.rs
@@ -60,9 +60,6 @@ impl Snippet for UnsafeSetLength {
                     write_mem
                     // Stack: *list list_length
 
-                    pop
-                    // Stack: *list
-
                     return
                 "
         )

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -278,8 +278,8 @@ pub fn simulate_snippet<T: Snippet>(
 
     // Prepend the snippet's code with code that injects expected memory
     for (address, value) in execution_state.memory.iter() {
-        code.push(format!("push {address} push {value} write_mem pop pop\n"));
-        inflated_clock_cycles += 5;
+        code.push(format!("push {address} push {value} write_mem pop\n"));
+        inflated_clock_cycles += 4;
     }
 
     // Compile the snippet and its library dependencies

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use itertools::Itertools;
 use twenty_first::shared_math::b_field_element::BFieldElement;
 
+use crate::library::Library;
 use crate::snippet::Snippet;
 use crate::ExecutionResult;
 
@@ -79,7 +80,7 @@ pub fn rust_tasm_equivalence_prop<T: Snippet>(
     assert_eq!(
         tasm_stack,
         rust_stack,
-        "Rust code must match TVM for `{}`\n\nTVM: {}\n\nRust: {}",
+        "Rust code must match TVM for `{}`\n\nTVM: {}\n\nRust: {}. Code was: {}",
         snippet_struct.entrypoint(),
         tasm_stack
             .iter()
@@ -91,6 +92,7 @@ pub fn rust_tasm_equivalence_prop<T: Snippet>(
             .map(|x| x.to_string())
             .collect_vec()
             .join(","),
+        snippet_struct.function_body(&mut Library::default())
     );
     if let Some(expected) = expected {
         assert_eq!(
@@ -128,7 +130,10 @@ pub fn rust_tasm_equivalence_prop<T: Snippet>(
             .map(|x| format!("({} => {})", x.0, x.1))
             .collect_vec()
             .join(",");
-        panic!("Memory for both implementations must match after execution.\n\nTVM: {tasm_mem_str}\n\nRust: {rust_mem_str}",)
+        panic!(
+            "Memory for both implementations must match after execution.\n\nTVM: {tasm_mem_str}\n\nRust: {rust_mem_str}. Code was:\n\n {}",
+            snippet_struct.function_body(&mut Library::default())
+        );
     }
 
     // Write back memory to be able to probe it in individual tests


### PR DESCRIPTION
This involves two changes:
- behavior of `write_mem` and `read_mem` have changed as they now change the stack height.
- Hash function was changed from `RescuePrimeRegular` to `Tip5`.

The table heights are all reduced by upgrading to 0.18.0. Specifically `calculate_new_peaks_from_append` (that still uses `unsafe` lists) sees a 10%+ drop in processor table height. From 5758 to 5091 for the "common case" and 11803 to 10432 for the "worst case". `calculate_new_peaks_from_leaf_mutation` sees a drop from 3138 to 2978 for "common case" and 6109 to 5789 in "worst case".

`tasm_mmr_verify_from_memory` sees a 3 % drop for "common case" and a 5 % drop for "worst case".

These MMR algorithms should be rewritten to use safe lists and the dynamic allocator though. That will yield a slight performance hit but probably one that's smaller than the speedup from this merge. See #27. 