### PR TITLE
fix sponge state mismatch

### DIFF
--- a/tasm-lib/benchmarks/tasm_list_higher_order_safeimplu32_u32_filter_test_hash_xfield_element_lsb.json
+++ b/tasm-lib/benchmarks/tasm_list_higher_order_safeimplu32_u32_filter_test_hash_xfield_element_lsb.json
@@ -3,14 +3,14 @@
     "name": "tasm_list_higher_order_safeimplu32_u32_filter_test_hash_xfield_element_lsb",
     "clock_cycle_count": 349,
     "hash_table_height": 0,
-    "u32_table_height": 152,
+    "u32_table_height": 165,
     "case": "CommonCase"
   },
   {
     "name": "tasm_list_higher_order_safeimplu32_u32_filter_test_hash_xfield_element_lsb",
     "clock_cycle_count": 1126,
     "hash_table_height": 0,
-    "u32_table_height": 588,
+    "u32_table_height": 603,
     "case": "WorstCase"
   }
 ]

--- a/tasm-lib/benchmarks/tasm_list_higher_order_safeimplu32_u32_map_test_hash_xfield_element.json
+++ b/tasm-lib/benchmarks/tasm_list_higher_order_safeimplu32_u32_map_test_hash_xfield_element.json
@@ -3,14 +3,14 @@
     "name": "tasm_list_higher_order_safeimplu32_u32_map_test_hash_xfield_element",
     "clock_cycle_count": 604,
     "hash_table_height": 0,
-    "u32_table_height": 37,
+    "u32_table_height": 55,
     "case": "CommonCase"
   },
   {
     "name": "tasm_list_higher_order_safeimplu32_u32_map_test_hash_xfield_element",
     "clock_cycle_count": 5480,
     "hash_table_height": 0,
-    "u32_table_height": 385,
+    "u32_table_height": 400,
     "case": "WorstCase"
   }
 ]

--- a/tasm-lib/benchmarks/tasm_list_higher_order_safeimplu32_u32_zip_xfe_with_digest.json
+++ b/tasm-lib/benchmarks/tasm_list_higher_order_safeimplu32_u32_zip_xfe_with_digest.json
@@ -3,14 +3,14 @@
     "name": "tasm_list_higher_order_safeimplu32_u32_zip_xfe_with_digest",
     "clock_cycle_count": 3412,
     "hash_table_height": 0,
-    "u32_table_height": 24,
+    "u32_table_height": 25,
     "case": "CommonCase"
   },
   {
     "name": "tasm_list_higher_order_safeimplu32_u32_zip_xfe_with_digest",
     "clock_cycle_count": 2372,
     "hash_table_height": 0,
-    "u32_table_height": 21,
+    "u32_table_height": 22,
     "case": "WorstCase"
   }
 ]

--- a/tasm-lib/benchmarks/tasm_list_higher_order_unsafeimplu32_u32_filter_test_hash_xfield_element_lsb.json
+++ b/tasm-lib/benchmarks/tasm_list_higher_order_unsafeimplu32_u32_filter_test_hash_xfield_element_lsb.json
@@ -3,14 +3,14 @@
     "name": "tasm_list_higher_order_unsafeimplu32_u32_filter_test_hash_xfield_element_lsb",
     "clock_cycle_count": 304,
     "hash_table_height": 0,
-    "u32_table_height": 145,
+    "u32_table_height": 158,
     "case": "CommonCase"
   },
   {
     "name": "tasm_list_higher_order_unsafeimplu32_u32_filter_test_hash_xfield_element_lsb",
     "clock_cycle_count": 1033,
     "hash_table_height": 0,
-    "u32_table_height": 538,
+    "u32_table_height": 553,
     "case": "WorstCase"
   }
 ]

--- a/tasm-lib/benchmarks/tasm_list_higher_order_unsafeimplu32_u32_map_test_hash_xfield_element.json
+++ b/tasm-lib/benchmarks/tasm_list_higher_order_unsafeimplu32_u32_map_test_hash_xfield_element.json
@@ -3,14 +3,14 @@
     "name": "tasm_list_higher_order_unsafeimplu32_u32_map_test_hash_xfield_element",
     "clock_cycle_count": 516,
     "hash_table_height": 0,
-    "u32_table_height": 13,
+    "u32_table_height": 31,
     "case": "CommonCase"
   },
   {
     "name": "tasm_list_higher_order_unsafeimplu32_u32_map_test_hash_xfield_element",
     "clock_cycle_count": 4748,
     "hash_table_height": 0,
-    "u32_table_height": 21,
+    "u32_table_height": 36,
     "case": "WorstCase"
   }
 ]

--- a/tasm-lib/benchmarks/tasm_list_higher_order_unsafeimplu32_u32_zip_xfe_with_digest.json
+++ b/tasm-lib/benchmarks/tasm_list_higher_order_unsafeimplu32_u32_zip_xfe_with_digest.json
@@ -3,14 +3,14 @@
     "name": "tasm_list_higher_order_unsafeimplu32_u32_zip_xfe_with_digest",
     "clock_cycle_count": 3394,
     "hash_table_height": 0,
-    "u32_table_height": 18,
+    "u32_table_height": 19,
     "case": "CommonCase"
   },
   {
     "name": "tasm_list_higher_order_unsafeimplu32_u32_zip_xfe_with_digest",
     "clock_cycle_count": 2354,
     "hash_table_height": 0,
-    "u32_table_height": 16,
+    "u32_table_height": 17,
     "case": "WorstCase"
   }
 ]

--- a/tasm-lib/benchmarks/tasm_neptune_mutator_get_swbf_indices_1048576_45.json
+++ b/tasm-lib/benchmarks/tasm_neptune_mutator_get_swbf_indices_1048576_45.json
@@ -1,16 +1,16 @@
 [
   {
     "name": "tasm_neptune_mutator_get_swbf_indices_1048576_45",
-    "clock_cycle_count": 4977,
+    "clock_cycle_count": 5830,
     "hash_table_height": 0,
-    "u32_table_height": 4623,
+    "u32_table_height": 4601,
     "case": "CommonCase"
   },
   {
     "name": "tasm_neptune_mutator_get_swbf_indices_1048576_45",
-    "clock_cycle_count": 4977,
+    "clock_cycle_count": 5830,
     "hash_table_height": 0,
-    "u32_table_height": 4497,
+    "u32_table_height": 4475,
     "case": "WorstCase"
   }
 ]

--- a/tasm-lib/src/arithmetic/bfe/primitive_root_of_unity.rs
+++ b/tasm-lib/src/arithmetic/bfe/primitive_root_of_unity.rs
@@ -404,7 +404,7 @@ mod tests {
     use crate::linker::link_for_isolated_run;
     use crate::snippet::RustShadow;
     use crate::test_helpers::test_rust_equivalence_given_complete_state;
-    use crate::{execute_with_terminal_state, program_with_state_preparation, VmHasherState};
+    use crate::{execute_with_terminal_state, prepend_state_preparation, VmHasherState};
 
     #[test]
     fn primitive_root_of_unity_pbt() {
@@ -482,12 +482,7 @@ mod tests {
             });
 
             // Run on Triton
-            let program = program_with_state_preparation(
-                &code,
-                &init_stack,
-                &mut NonDeterminism::new(vec![]),
-                None,
-            );
+            let program = prepend_state_preparation(&code, &init_stack);
             let tvm_result =
                 execute_with_terminal_state(&program, &[], &mut NonDeterminism::new(vec![]), None);
 

--- a/tasm-lib/src/arithmetic/u32/safepow.rs
+++ b/tasm-lib/src/arithmetic/u32/safepow.rs
@@ -201,7 +201,7 @@ mod tests {
     use crate::linker::link_for_isolated_run;
     use crate::snippet::RustShadow;
     use crate::test_helpers::test_rust_equivalence_given_complete_state;
-    use crate::{execute_with_terminal_state, program_with_state_preparation, VmHasherState};
+    use crate::{execute_with_terminal_state, prepend_state_preparation, VmHasherState};
 
     #[test]
     fn u32_pow_pbt() {
@@ -326,12 +326,7 @@ mod tests {
             });
 
             // Run on Triton
-            let program = program_with_state_preparation(
-                &code,
-                &init_stack,
-                &mut NonDeterminism::new(vec![]),
-                None,
-            );
+            let program = prepend_state_preparation(&code, &init_stack);
             let tvm_result =
                 execute_with_terminal_state(&program, &[], &mut NonDeterminism::new(vec![]), None);
 

--- a/tasm-lib/src/hashing/sample_indices.rs
+++ b/tasm-lib/src/hashing/sample_indices.rs
@@ -4,429 +4,32 @@ use itertools::Itertools;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use triton_vm::{triton_asm, NonDeterminism};
 use twenty_first::{
-    shared_math::{
-        b_field_element::BFieldElement,
-        other::is_power_of_two,
-        tip5::{Tip5, STATE_SIZE},
-    },
-    util_types::algebraic_hasher::{AlgebraicHasher, Domain, SpongeHasher},
+    shared_math::{b_field_element::BFieldElement, tip5::STATE_SIZE},
+    util_types::algebraic_hasher::AlgebraicHasher,
 };
 
 use crate::{
     empty_stack,
     list::{
         self,
-        safeimplu32::{new::SafeNew, push::SafePush, set_length::SafeSetLength},
-        unsafeimplu32::{new::UnsafeNew, push::UnsafePush, set_length::UnsafeSetLength},
+        safeimplu32::{new::SafeNew, push::SafePush},
+        unsafeimplu32::{new::UnsafeNew, push::UnsafePush},
         ListType,
     },
     procedure::Procedure,
     rust_shadowing_helper_functions,
-    snippet::{BasicSnippet, DataType, DeprecatedSnippet},
-    ExecutionState, VmHasher, VmHasherState,
+    snippet::{BasicSnippet, DataType},
+    VmHasher, VmHasherState,
 };
 
+/// Sample n pseudorandom integers
+/// between 0 and k. It does this by squeezing the sponge. It is the
+/// caller's responsibility to ensure that the sponge is initialized
+/// to the right state.
 #[derive(Clone, Debug)]
 pub struct SampleIndices {
     pub list_type: ListType,
 }
-
-/// SampleIndices samples n pseudorandom integers
-/// between 0 and k. It does this by squeezing the sponge. It is the
-/// caller's responsibility to ensure that the sponge is initialized
-/// to the right state.
-impl SampleIndices {
-    fn test_state(number: usize, upper_bound: u32) -> ExecutionState {
-        ExecutionState {
-            stack: [
-                empty_stack(),
-                vec![
-                    BFieldElement::new(number as u64),
-                    BFieldElement::new(upper_bound as u64),
-                ],
-            ]
-            .concat(),
-            std_in: vec![],
-            nondeterminism: NonDeterminism::new(vec![]),
-            memory: HashMap::new(),
-            words_allocated: 1,
-        }
-    }
-}
-
-// impl DeprecatedSnippet for SampleIndices {
-//     fn entrypoint_name(&self) -> String {
-//         format!("tasm_hashing_sample_indices_to_{}_list", self.list_type)
-//     }
-
-//     fn input_field_names(&self) -> Vec<String>
-//     where
-//         Self: Sized,
-//     {
-//         vec!["number".to_string(), "upper_bound".to_string()]
-//     }
-
-//     fn input_types(&self) -> Vec<crate::snippet::DataType> {
-//         vec![DataType::U32, DataType::U32]
-//     }
-
-//     fn output_types(&self) -> Vec<crate::snippet::DataType> {
-//         vec![DataType::List(Box::new(DataType::U32))]
-//     }
-
-//     fn output_field_names(&self) -> Vec<String>
-//     where
-//         Self: Sized,
-//     {
-//         vec!["index_list".to_string()]
-//     }
-
-//     fn stack_diff(&self) -> isize
-//     where
-//         Self: Sized,
-//     {
-//         -1
-//     }
-
-//     fn function_code(&self, library: &mut crate::library::Library) -> String {
-//         let entrypoint = self.entrypoint_name();
-//         let new_list = match self.list_type {
-//             ListType::Safe => library.import(Box::new(SafeNew(DataType::U32))),
-//             ListType::Unsafe => library.import(Box::new(UnsafeNew(DataType::U32))),
-//         };
-//         let set_length = match self.list_type {
-//             ListType::Safe => library.import(Box::new(SafeSetLength(DataType::U32))),
-//             ListType::Unsafe => library.import(Box::new(UnsafeSetLength(DataType::U32))),
-//         };
-//         let safety_offset = match self.list_type {
-//             ListType::Safe => 2,
-//             ListType::Unsafe => 1,
-//         };
-//         let minus_safety_offset = match self.list_type {
-//             ListType::Safe => -2,
-//             ListType::Unsafe => -1,
-//         };
-
-//         let process_top = format!("
-//                 // _ number upper_bound-1 address list_index prn^10
-//                 dup 10 // _ number upper_bound-1 address list_index prn^10 list_index
-//                 dup 14 // _ number upper_bound-1 address list_index prn^10 list_index number
-//                 eq // _ number upper_bound-1 address list_index prn^10 list_index==number
-//                 dup 1  // _ number upper_bound-1 address list_index prn^10 list_index==number prn0
-//                 push -1 eq  // _ number upper_bound-1 address list_index prn^10 list_index==number prn0==-1
-//                 add  // _ number upper_bound-1 address list_index prn^10 list_index==number||prn0==-1
-//                 push 0 eq // _ number upper_bound-1 address list_index prn^10 list_index!=number&&prn0!=-1
-//                 skiz call {entrypoint}_process_top_function_body
-//                 // _ number upper_bound-1 address list_index prn^10
-//         ");
-
-//         let rotate_10 = "
-//             swap 9
-//             swap 8
-//             swap 7
-//             swap 6
-//             swap 5
-//             swap 4
-//             swap 3
-//             swap 2
-//             swap 1"
-//             .to_string();
-
-//         format!(
-//             "
-//             // BEFORE: _ number upper_bound
-//             // AFTER: _ list
-//             {entrypoint}:
-//                 // assert power of two
-//                 dup 0 dup 0 // _ number upper_bound upper_bound upper_bound
-//                 push -1 add and // _ number upper_bound upper_bound&(upper_bound-1)
-//                 push 0 eq assert // asserts that upper_bound = 2^k for some k
-//                 push -1 add // _ number upper_bound-1
-
-//                 // create list
-//                 dup 1 // _ number upper_bound-1 number
-//                 call {new_list} // _ number upper_bound-1 list
-//                 dup 2 //  _ number upper_bound-1 list number
-//                 call {set_length} // _ number upper_bound-1 list
-//                 push {safety_offset} add // _ number upper_bound-1 address
-
-//                 // prepare and call loop
-//                 push 0 // _ number upper_bound-1 address 0
-//                 push 0 push 0 push 0 push 0 push 0 push 0 push 0 push 0 push 0 push 0
-//                 // _ number upper_bound-1 address list_index 0 0 0 0 0 0 0 0 0 0
-
-//                 sponge_squeeze // overwrite top 10 elements with fresh randomness
-//                 call {entrypoint}_loop // _ number upper_bound-1 address number prn9 prn8 prn7 prn6 prn5 prn4 prn3 prn2 prn1 prn0
-
-//                 // clean up stack
-//                 pop pop pop pop pop pop pop pop pop pop // _ number upper_bound-1 address number
-//                 pop // _ number upper_bound-1 address
-//                 swap 2  // _ address  upper_bound-1 number
-//                 pop pop // _ address
-//                 push {minus_safety_offset} add // _ list
-
-//                 return
-
-//             // INVARIANT: _ number upper_bound-1 list list_index prn9 prn8 prn7 prn6 prn5 prn4 prn3 prn2 prn1 prn0
-//             {entrypoint}_loop:
-//                 // evaluate termination
-//                 dup 13 // _ number upper_bound-1 address list_index prn9 prn8 prn7 prn6 prn5 prn4 prn3 prn2 prn1 prn0 number
-//                 dup 11 // _ number upper_bound-1 address list_index prn9 prn8 prn7 prn6 prn5 prn4 prn3 prn2 prn1 prn0 number list_index
-//                 eq // _ number upper_bound-1 address list_index prn9 prn8 prn7 prn6 prn5 prn4 prn3 prn2 prn1 prn0 number==list_index
-
-//                 skiz return // continue if unequal
-//                 // _ number upper_bound-1 address list_index  prn9 prn8 prn7 prn6 prn5 prn4 prn3 prn2 prn1 prn0
-
-//                 {process_top}
-//                 {rotate_10}
-
-//                 {process_top}
-//                 {rotate_10}
-
-//                 {process_top}
-//                 {rotate_10}
-
-//                 {process_top}
-//                 {rotate_10}
-
-//                 {process_top}
-//                 {rotate_10}
-
-//                 {process_top}
-//                 {rotate_10}
-
-//                 {process_top}
-//                 {rotate_10}
-
-//                 {process_top}
-//                 {rotate_10}
-
-//                 {process_top}
-//                 {rotate_10}
-
-//                 {process_top}
-//                 {rotate_10}
-
-//                 // _ number upper_bound-1 address list_index prn9 prn8 prn7 prn6 prn5 prn4 prn3 prn2 prn1 prn0
-
-//                 dup 10
-//                 push 0 eq
-//                 push 0 eq
-//                 assert // crash if list_index == 0
-
-//                 sponge_squeeze // overwrite top 10 elements with fresh randomness
-
-//                 recurse
-
-//             {entrypoint}_process_top_function_body:
-//                 dup 0  //  _ number upper_bound-1 address list_index prn^10 prn0
-//                 split //  _ number upper_bound-1 address list_index prn^10 hi lo
-//                 dup 13 //  _ number upper_bound-1 address list_index prn^10 hi lo address
-//                 dup 13 //  _ number upper_bound-1 address list_index prn^10 hi lo address list_index
-//                 add //  _ number upper_bound-1 address list_index prn^10 hi lo address+list_index
-
-//                 swap 1 //  _ number upper_bound-1 address list_index prn^10 hi address+list_index lo
-//                 dup 15 // _ number upper_bound-1 address list_index prn^10 hi address+list_index lo upper_bound-1
-//                 and // _ number upper_bound-1 address list_index prn^10 hi address+list_index (lo&(upper_bound-1))
-
-//                 write_mem  // _ number upper_bound-1 address list_index prn^10 hi address+list_index
-//                 pop pop // _ number upper_bound-1 address list_index prn^10
-
-//                 swap 10
-//                 push 1 add
-//                 swap 10
-//                 // _ number upper_bound-1 address list_index+1 prn^10
-//                 return
-//             "
-//         )
-//     }
-
-//     fn crash_conditions(&self) -> Vec<String>
-//     where
-//         Self: Sized,
-//     {
-//         vec![
-//             "Number exceeds u32::MAX".to_string(),
-//             "Upper bound is not a power of two".to_string(),
-//         ]
-//     }
-
-//     fn gen_input_states(&self) -> Vec<crate::ExecutionState>
-//     where
-//         Self: Sized,
-//     {
-//         vec![
-//             Self::test_state(0, 1 << 12),
-//             Self::test_state(1, 1 << 12),
-//             Self::test_state(10, 1 << 12),
-//             Self::test_state(11, 1 << 12),
-//             Self::test_state(45, 1 << 12),
-//             Self::test_state(4, 1 << 31),
-//         ]
-//     }
-
-//     fn common_case_input_state(&self) -> crate::ExecutionState
-//     where
-//         Self: Sized,
-//     {
-//         Self::test_state(45, 1 << 12)
-//     }
-
-//     fn worst_case_input_state(&self) -> crate::ExecutionState
-//     where
-//         Self: Sized,
-//     {
-//         Self::test_state(160, 1 << 23)
-//     }
-
-//     fn rust_shadowing(
-//         &self,
-//         stack: &mut Vec<triton_vm::BFieldElement>,
-//         _std_in: Vec<triton_vm::BFieldElement>,
-//         _secret_in: Vec<triton_vm::BFieldElement>,
-//         memory: &mut std::collections::HashMap<triton_vm::BFieldElement, triton_vm::BFieldElement>,
-//     ) where
-//         Self: Sized,
-//     {
-//         let upper_bound = stack.pop().unwrap().value() as u32;
-//         let number = stack.pop().unwrap().value() as usize;
-
-//         assert!(
-//             is_power_of_two(upper_bound),
-//             "Upper bound {upper_bound} must be a power of two"
-//         );
-
-//         // helper functions
-//         let set_element = match self.list_type {
-//             ListType::Safe => rust_shadowing_helper_functions::safe_list::safe_list_set,
-//             ListType::Unsafe => rust_shadowing_helper_functions::unsafe_list::unsafe_list_set,
-//         };
-
-//         // sample indices
-//         let mut indices: Vec<u32> = vec![];
-//         let mut sponge_state = VmHasherState::new(Domain::VariableLength);
-//         let mut squeezed = vec![];
-//         while indices.len() < number {
-//             if squeezed.is_empty() {
-//                 squeezed = Tip5::squeeze(&mut sponge_state)
-//                     .into_iter()
-//                     .rev()
-//                     .collect_vec();
-//             }
-
-//             let element = squeezed.pop().unwrap();
-//             if element != BFieldElement::new(BFieldElement::MAX) {
-//                 indices.push(element.value() as u32 % upper_bound);
-//             }
-//         }
-
-//         // double-shadow with twenty-first
-//         let twenty_first_indices = VmHasher::sample_indices(
-//             &mut VmHasherState::new(Domain::VariableLength),
-//             upper_bound,
-//             number,
-//         );
-//         assert_eq!(twenty_first_indices, indices);
-
-//         // create list object
-//         let capacity = number;
-//         let list = match self.list_type {
-//             ListType::Safe => {
-//                 // Push capacity to stack
-//                 stack.push(BFieldElement::new(capacity as u64));
-//                 list::safeimplu32::new::SafeNew(DataType::U32).rust_shadowing(
-//                     stack,
-//                     _std_in.clone(),
-//                     _secret_in.clone(),
-//                     memory,
-//                 );
-//                 stack.pop().unwrap()
-//             }
-//             ListType::Unsafe => {
-//                 stack.push(BFieldElement::new(capacity as u64));
-//                 list::unsafeimplu32::new::UnsafeNew(DataType::U32).rust_shadowing(
-//                     stack,
-//                     _std_in.clone(),
-//                     _secret_in.clone(),
-//                     memory,
-//                 );
-//                 stack.pop().unwrap()
-//             }
-//         };
-
-//         // set length
-//         stack.push(list);
-//         stack.push(BFieldElement::new(number as u64));
-//         match self.list_type {
-//             ListType::Safe => {
-//                 list::safeimplu32::set_length::SafeSetLength(DataType::U32)
-//                     .rust_shadowing(stack, _std_in, _secret_in, memory);
-//             }
-//             ListType::Unsafe => {
-//                 list::unsafeimplu32::set_length::UnsafeSetLength(DataType::U32)
-//                     .rust_shadowing(stack, _std_in, _secret_in, memory);
-//             }
-//         }
-//         stack.pop();
-
-//         // store list to memory
-//         for (i, index) in indices.into_iter().enumerate() {
-//             set_element(
-//                 list,
-//                 i,
-//                 vec![BFieldElement::new(index as u64)],
-//                 memory,
-//                 DataType::U32.get_size(),
-//             );
-//         }
-
-//         stack.push(list);
-//     }
-// }
-
-// #[cfg(test)]
-// mod tests {
-
-//     use crate::{list::ListType, test_helpers::test_rust_equivalence_multiple_deprecated};
-
-//     use super::SampleIndices;
-
-//     #[test]
-//     fn new_prop_test() {
-//         test_rust_equivalence_multiple_deprecated(
-//             &SampleIndices {
-//                 list_type: ListType::Safe,
-//             },
-//             true,
-//         );
-//         test_rust_equivalence_multiple_deprecated(
-//             &SampleIndices {
-//                 list_type: ListType::Unsafe,
-//             },
-//             true,
-//         );
-//     }
-// }
-
-// #[cfg(test)]
-// mod benches {
-//     use super::*;
-//     use crate::snippet_bencher::bench_and_write;
-
-//     #[test]
-//     fn sample_indices_benchmark_safe() {
-//         bench_and_write(SampleIndices {
-//             list_type: ListType::Safe,
-//         });
-//     }
-
-//     #[test]
-//     fn sample_indices_benchmark_unsafe() {
-//         bench_and_write(SampleIndices {
-//             list_type: ListType::Unsafe,
-//         });
-//     }
-// }
 
 impl BasicSnippet for SampleIndices {
     fn inputs(&self) -> Vec<(DataType, String)> {
@@ -454,9 +57,7 @@ impl BasicSnippet for SampleIndices {
         let entrypoint = self.entrypoint();
         let main_loop = format!("{entrypoint}_main_loop");
         let then_reduce_and_save = format!("{entrypoint}_then_reduce_and_save");
-        let then_reduce_and_save_special = format!("{entrypoint}_then_reduce_and_save_special");
         let else_drop_tip = format!("{entrypoint}_else_drop_tip");
-        let else_drop_tip_special = format!("{entrypoint}_else_drop_tip_special");
         let new_list = match self.list_type {
             ListType::Safe => library.import(Box::new(SafeNew(DataType::U32))),
             ListType::Unsafe => library.import(Box::new(UnsafeNew(DataType::U32))),
@@ -476,14 +77,16 @@ impl BasicSnippet for SampleIndices {
 
         let if_can_sample = triton_asm! (
             // BEFORE: _ prn number upper_bound *indices
-            // AFTER: _ prn number upper_bound *indices can_use
+            // AFTER: _ prn number upper_bound *indices ~can_use can_use
             dup 0 call {length}         // _ prn number upper_bound *indices length
             dup 3 eq                    // _ prn number upper_bound *indices length==number
             push 0 eq                   // _ prn number upper_bound *indices length!=number
             dup 4 push -1 eq            // _ prn number upper_bound *indices length!=number prn==max
             push 0 eq                   // _ prn number upper_bound *indices length!=number prn!=max
             mul                         // _ prn number upper_bound *indices length!=number&&prn!=max
-            push 1337 assert
+            dup 0                       // _ prn number upper_bound *indices length!=number&&prn!=max length!=number&&prn!=max
+            push 0 eq                   // _ prn number upper_bound *indices length!=number&&prn!=max ~(length!=number&&prn!=max)
+            swap 1                      // _ prn number upper_bound *indices ~(length!=number&&prn!=max) length!=number&&prn!=max
         );
 
         triton_asm! (
@@ -522,47 +125,52 @@ impl BasicSnippet for SampleIndices {
                 {&if_can_sample}
                 skiz call {then_reduce_and_save}
                 skiz call {else_drop_tip}
-                {&if_can_sample}
-                skiz call {then_reduce_and_save}
-                skiz call {else_drop_tip}
-                {&if_can_sample}
-                skiz call {then_reduce_and_save}
-                skiz call {else_drop_tip}
-                {&if_can_sample}
-                skiz call {then_reduce_and_save}
-                skiz call {else_drop_tip}
-                // push 1340 assert
-                {&if_can_sample}    // _ number upper_bound-1 *indices 1
-                push 1341 assert
-                skiz call {then_reduce_and_save_special}
-                skiz call {else_drop_tip_special}
 
                 {&if_can_sample}
                 skiz call {then_reduce_and_save}
                 skiz call {else_drop_tip}
+
                 {&if_can_sample}
                 skiz call {then_reduce_and_save}
                 skiz call {else_drop_tip}
+
                 {&if_can_sample}
                 skiz call {then_reduce_and_save}
                 skiz call {else_drop_tip}
+
                 {&if_can_sample}
                 skiz call {then_reduce_and_save}
                 skiz call {else_drop_tip}
+
+
+                {&if_can_sample}
+                skiz call {then_reduce_and_save}
+                skiz call {else_drop_tip}
+
+                {&if_can_sample}
+                skiz call {then_reduce_and_save}
+                skiz call {else_drop_tip}
+
+                {&if_can_sample}
+                skiz call {then_reduce_and_save}
+                skiz call {else_drop_tip}
+
+                {&if_can_sample}
+                skiz call {then_reduce_and_save}
+                skiz call {else_drop_tip}
+
                 {&if_can_sample}
                 skiz call {then_reduce_and_save}
                 skiz call {else_drop_tip}         // _ number upper_bound-1 *indices number upper_bound-1 *indices
 
-
-                dup 0 call {length} push 1338 assert
-
                 // return to invariant and repeat
-                pop pop pop
+                pop pop pop                         // _ number upper_bound-1 *indices
                 recurse
 
-            // BEFORE: _ prn number upper_bound-1 *indices
+            // BEFORE: _ prn number upper_bound-1 *indices 0
             // AFTER: _ number upper_bound-1 *indices 0
             {then_reduce_and_save}:
+                pop                     // _ prn number upper_bound-1 *indices
                 swap 2 swap 3           // _ number *indices upper_bound-1 prn
                 split                   // _ number *indices upper_bound-1 hi lo
                 dup 2 and               // _ number *indices upper_bound-1 hi index
@@ -576,37 +184,12 @@ impl BasicSnippet for SampleIndices {
                 return
 
             // BEFORE: _ prn number upper_bound-1 *indices
-            // AFTER: _ number upper_bound-1 *indices 0
-            {then_reduce_and_save_special}:
-                swap 2 swap 3           // _ number *indices upper_bound-1 prn
-                split                   // _ number *indices upper_bound-1 hi lo
-                dup 2 and               // _ number *indices upper_bound-1 hi index
-                swap 1 pop              // _ number *indices upper_bound-1 index
-
-                swap 1 swap 2 swap 1    // _ number upper_bound-1 *indices index
-                dup 1 swap 1            // _ number upper_bound-1 *indices *indices index
-                call {push_element}     // _ number upper_bound-1 *indices
-
-                dup 0 call {length} push 1339 assert
-
-                push 0
-                return
-
-            // BEFORE: _ prn number upper_bound-1 *indices
             // AFTER: _ number upper_bound-1 *indices
             {else_drop_tip}:
                 swap 2 swap 3           // _ number *indices upper_bound-1 prn
                 pop swap 1              // _ number upper_bound-1 *indices
                 return
 
-            // BEFORE: _ prn number upper_bound-1 *indices
-            // AFTER: _ number upper_bound-1 *indices
-            {else_drop_tip_special}:
-                dup 0 call {length}
-                push 1337 assert
-                swap 2 swap 3           // _ number *indices upper_bound-1 prn
-                pop swap 1              // _ number upper_bound-1 *indices
-                return
         )
     }
 }
@@ -673,12 +256,19 @@ impl Procedure for SampleIndices {
         let number = if let Some(case) = bench_case {
             match case {
                 crate::snippet_bencher::BenchmarkCase::CommonCase => 45,
-                crate::snippet_bencher::BenchmarkCase::WorstCase => 105,
+                crate::snippet_bencher::BenchmarkCase::WorstCase => 160,
             }
         } else {
             rng.gen_range(0..20)
         };
-        let upper_bound = 1 << rng.gen_range(0..20);
+        let upper_bound = if let Some(case) = bench_case {
+            match case {
+                crate::snippet_bencher::BenchmarkCase::CommonCase => 1 << 12,
+                crate::snippet_bencher::BenchmarkCase::WorstCase => 1 << 23,
+            }
+        } else {
+            1 << rng.gen_range(0..20)
+        };
 
         let mut stack = empty_stack();
         stack.push(BFieldElement::new(number as u64));

--- a/tasm-lib/src/hashing/sample_indices.rs
+++ b/tasm-lib/src/hashing/sample_indices.rs
@@ -1,9 +1,14 @@
 use std::collections::HashMap;
 
 use itertools::Itertools;
-use triton_vm::NonDeterminism;
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use triton_vm::{triton_asm, NonDeterminism};
 use twenty_first::{
-    shared_math::{b_field_element::BFieldElement, other::is_power_of_two, tip5::Tip5},
+    shared_math::{
+        b_field_element::BFieldElement,
+        other::is_power_of_two,
+        tip5::{Tip5, STATE_SIZE},
+    },
     util_types::algebraic_hasher::{AlgebraicHasher, Domain, SpongeHasher},
 };
 
@@ -11,12 +16,13 @@ use crate::{
     empty_stack,
     list::{
         self,
-        safeimplu32::{new::SafeNew, set_length::SafeSetLength},
-        unsafeimplu32::{new::UnsafeNew, set_length::UnsafeSetLength},
+        safeimplu32::{new::SafeNew, push::SafePush, set_length::SafeSetLength},
+        unsafeimplu32::{new::UnsafeNew, push::UnsafePush, set_length::UnsafeSetLength},
         ListType,
     },
+    procedure::Procedure,
     rust_shadowing_helper_functions,
-    snippet::{DataType, DeprecatedSnippet},
+    snippet::{BasicSnippet, DataType, DeprecatedSnippet},
     ExecutionState, VmHasher, VmHasherState,
 };
 
@@ -48,376 +54,674 @@ impl SampleIndices {
     }
 }
 
-impl DeprecatedSnippet for SampleIndices {
-    fn entrypoint_name(&self) -> String {
-        format!("tasm_hashing_sample_indices_to_{}_list", self.list_type)
+// impl DeprecatedSnippet for SampleIndices {
+//     fn entrypoint_name(&self) -> String {
+//         format!("tasm_hashing_sample_indices_to_{}_list", self.list_type)
+//     }
+
+//     fn input_field_names(&self) -> Vec<String>
+//     where
+//         Self: Sized,
+//     {
+//         vec!["number".to_string(), "upper_bound".to_string()]
+//     }
+
+//     fn input_types(&self) -> Vec<crate::snippet::DataType> {
+//         vec![DataType::U32, DataType::U32]
+//     }
+
+//     fn output_types(&self) -> Vec<crate::snippet::DataType> {
+//         vec![DataType::List(Box::new(DataType::U32))]
+//     }
+
+//     fn output_field_names(&self) -> Vec<String>
+//     where
+//         Self: Sized,
+//     {
+//         vec!["index_list".to_string()]
+//     }
+
+//     fn stack_diff(&self) -> isize
+//     where
+//         Self: Sized,
+//     {
+//         -1
+//     }
+
+//     fn function_code(&self, library: &mut crate::library::Library) -> String {
+//         let entrypoint = self.entrypoint_name();
+//         let new_list = match self.list_type {
+//             ListType::Safe => library.import(Box::new(SafeNew(DataType::U32))),
+//             ListType::Unsafe => library.import(Box::new(UnsafeNew(DataType::U32))),
+//         };
+//         let set_length = match self.list_type {
+//             ListType::Safe => library.import(Box::new(SafeSetLength(DataType::U32))),
+//             ListType::Unsafe => library.import(Box::new(UnsafeSetLength(DataType::U32))),
+//         };
+//         let safety_offset = match self.list_type {
+//             ListType::Safe => 2,
+//             ListType::Unsafe => 1,
+//         };
+//         let minus_safety_offset = match self.list_type {
+//             ListType::Safe => -2,
+//             ListType::Unsafe => -1,
+//         };
+
+//         let process_top = format!("
+//                 // _ number upper_bound-1 address list_index prn^10
+//                 dup 10 // _ number upper_bound-1 address list_index prn^10 list_index
+//                 dup 14 // _ number upper_bound-1 address list_index prn^10 list_index number
+//                 eq // _ number upper_bound-1 address list_index prn^10 list_index==number
+//                 dup 1  // _ number upper_bound-1 address list_index prn^10 list_index==number prn0
+//                 push -1 eq  // _ number upper_bound-1 address list_index prn^10 list_index==number prn0==-1
+//                 add  // _ number upper_bound-1 address list_index prn^10 list_index==number||prn0==-1
+//                 push 0 eq // _ number upper_bound-1 address list_index prn^10 list_index!=number&&prn0!=-1
+//                 skiz call {entrypoint}_process_top_function_body
+//                 // _ number upper_bound-1 address list_index prn^10
+//         ");
+
+//         let rotate_10 = "
+//             swap 9
+//             swap 8
+//             swap 7
+//             swap 6
+//             swap 5
+//             swap 4
+//             swap 3
+//             swap 2
+//             swap 1"
+//             .to_string();
+
+//         format!(
+//             "
+//             // BEFORE: _ number upper_bound
+//             // AFTER: _ list
+//             {entrypoint}:
+//                 // assert power of two
+//                 dup 0 dup 0 // _ number upper_bound upper_bound upper_bound
+//                 push -1 add and // _ number upper_bound upper_bound&(upper_bound-1)
+//                 push 0 eq assert // asserts that upper_bound = 2^k for some k
+//                 push -1 add // _ number upper_bound-1
+
+//                 // create list
+//                 dup 1 // _ number upper_bound-1 number
+//                 call {new_list} // _ number upper_bound-1 list
+//                 dup 2 //  _ number upper_bound-1 list number
+//                 call {set_length} // _ number upper_bound-1 list
+//                 push {safety_offset} add // _ number upper_bound-1 address
+
+//                 // prepare and call loop
+//                 push 0 // _ number upper_bound-1 address 0
+//                 push 0 push 0 push 0 push 0 push 0 push 0 push 0 push 0 push 0 push 0
+//                 // _ number upper_bound-1 address list_index 0 0 0 0 0 0 0 0 0 0
+
+//                 sponge_squeeze // overwrite top 10 elements with fresh randomness
+//                 call {entrypoint}_loop // _ number upper_bound-1 address number prn9 prn8 prn7 prn6 prn5 prn4 prn3 prn2 prn1 prn0
+
+//                 // clean up stack
+//                 pop pop pop pop pop pop pop pop pop pop // _ number upper_bound-1 address number
+//                 pop // _ number upper_bound-1 address
+//                 swap 2  // _ address  upper_bound-1 number
+//                 pop pop // _ address
+//                 push {minus_safety_offset} add // _ list
+
+//                 return
+
+//             // INVARIANT: _ number upper_bound-1 list list_index prn9 prn8 prn7 prn6 prn5 prn4 prn3 prn2 prn1 prn0
+//             {entrypoint}_loop:
+//                 // evaluate termination
+//                 dup 13 // _ number upper_bound-1 address list_index prn9 prn8 prn7 prn6 prn5 prn4 prn3 prn2 prn1 prn0 number
+//                 dup 11 // _ number upper_bound-1 address list_index prn9 prn8 prn7 prn6 prn5 prn4 prn3 prn2 prn1 prn0 number list_index
+//                 eq // _ number upper_bound-1 address list_index prn9 prn8 prn7 prn6 prn5 prn4 prn3 prn2 prn1 prn0 number==list_index
+
+//                 skiz return // continue if unequal
+//                 // _ number upper_bound-1 address list_index  prn9 prn8 prn7 prn6 prn5 prn4 prn3 prn2 prn1 prn0
+
+//                 {process_top}
+//                 {rotate_10}
+
+//                 {process_top}
+//                 {rotate_10}
+
+//                 {process_top}
+//                 {rotate_10}
+
+//                 {process_top}
+//                 {rotate_10}
+
+//                 {process_top}
+//                 {rotate_10}
+
+//                 {process_top}
+//                 {rotate_10}
+
+//                 {process_top}
+//                 {rotate_10}
+
+//                 {process_top}
+//                 {rotate_10}
+
+//                 {process_top}
+//                 {rotate_10}
+
+//                 {process_top}
+//                 {rotate_10}
+
+//                 // _ number upper_bound-1 address list_index prn9 prn8 prn7 prn6 prn5 prn4 prn3 prn2 prn1 prn0
+
+//                 dup 10
+//                 push 0 eq
+//                 push 0 eq
+//                 assert // crash if list_index == 0
+
+//                 sponge_squeeze // overwrite top 10 elements with fresh randomness
+
+//                 recurse
+
+//             {entrypoint}_process_top_function_body:
+//                 dup 0  //  _ number upper_bound-1 address list_index prn^10 prn0
+//                 split //  _ number upper_bound-1 address list_index prn^10 hi lo
+//                 dup 13 //  _ number upper_bound-1 address list_index prn^10 hi lo address
+//                 dup 13 //  _ number upper_bound-1 address list_index prn^10 hi lo address list_index
+//                 add //  _ number upper_bound-1 address list_index prn^10 hi lo address+list_index
+
+//                 swap 1 //  _ number upper_bound-1 address list_index prn^10 hi address+list_index lo
+//                 dup 15 // _ number upper_bound-1 address list_index prn^10 hi address+list_index lo upper_bound-1
+//                 and // _ number upper_bound-1 address list_index prn^10 hi address+list_index (lo&(upper_bound-1))
+
+//                 write_mem  // _ number upper_bound-1 address list_index prn^10 hi address+list_index
+//                 pop pop // _ number upper_bound-1 address list_index prn^10
+
+//                 swap 10
+//                 push 1 add
+//                 swap 10
+//                 // _ number upper_bound-1 address list_index+1 prn^10
+//                 return
+//             "
+//         )
+//     }
+
+//     fn crash_conditions(&self) -> Vec<String>
+//     where
+//         Self: Sized,
+//     {
+//         vec![
+//             "Number exceeds u32::MAX".to_string(),
+//             "Upper bound is not a power of two".to_string(),
+//         ]
+//     }
+
+//     fn gen_input_states(&self) -> Vec<crate::ExecutionState>
+//     where
+//         Self: Sized,
+//     {
+//         vec![
+//             Self::test_state(0, 1 << 12),
+//             Self::test_state(1, 1 << 12),
+//             Self::test_state(10, 1 << 12),
+//             Self::test_state(11, 1 << 12),
+//             Self::test_state(45, 1 << 12),
+//             Self::test_state(4, 1 << 31),
+//         ]
+//     }
+
+//     fn common_case_input_state(&self) -> crate::ExecutionState
+//     where
+//         Self: Sized,
+//     {
+//         Self::test_state(45, 1 << 12)
+//     }
+
+//     fn worst_case_input_state(&self) -> crate::ExecutionState
+//     where
+//         Self: Sized,
+//     {
+//         Self::test_state(160, 1 << 23)
+//     }
+
+//     fn rust_shadowing(
+//         &self,
+//         stack: &mut Vec<triton_vm::BFieldElement>,
+//         _std_in: Vec<triton_vm::BFieldElement>,
+//         _secret_in: Vec<triton_vm::BFieldElement>,
+//         memory: &mut std::collections::HashMap<triton_vm::BFieldElement, triton_vm::BFieldElement>,
+//     ) where
+//         Self: Sized,
+//     {
+//         let upper_bound = stack.pop().unwrap().value() as u32;
+//         let number = stack.pop().unwrap().value() as usize;
+
+//         assert!(
+//             is_power_of_two(upper_bound),
+//             "Upper bound {upper_bound} must be a power of two"
+//         );
+
+//         // helper functions
+//         let set_element = match self.list_type {
+//             ListType::Safe => rust_shadowing_helper_functions::safe_list::safe_list_set,
+//             ListType::Unsafe => rust_shadowing_helper_functions::unsafe_list::unsafe_list_set,
+//         };
+
+//         // sample indices
+//         let mut indices: Vec<u32> = vec![];
+//         let mut sponge_state = VmHasherState::new(Domain::VariableLength);
+//         let mut squeezed = vec![];
+//         while indices.len() < number {
+//             if squeezed.is_empty() {
+//                 squeezed = Tip5::squeeze(&mut sponge_state)
+//                     .into_iter()
+//                     .rev()
+//                     .collect_vec();
+//             }
+
+//             let element = squeezed.pop().unwrap();
+//             if element != BFieldElement::new(BFieldElement::MAX) {
+//                 indices.push(element.value() as u32 % upper_bound);
+//             }
+//         }
+
+//         // double-shadow with twenty-first
+//         let twenty_first_indices = VmHasher::sample_indices(
+//             &mut VmHasherState::new(Domain::VariableLength),
+//             upper_bound,
+//             number,
+//         );
+//         assert_eq!(twenty_first_indices, indices);
+
+//         // create list object
+//         let capacity = number;
+//         let list = match self.list_type {
+//             ListType::Safe => {
+//                 // Push capacity to stack
+//                 stack.push(BFieldElement::new(capacity as u64));
+//                 list::safeimplu32::new::SafeNew(DataType::U32).rust_shadowing(
+//                     stack,
+//                     _std_in.clone(),
+//                     _secret_in.clone(),
+//                     memory,
+//                 );
+//                 stack.pop().unwrap()
+//             }
+//             ListType::Unsafe => {
+//                 stack.push(BFieldElement::new(capacity as u64));
+//                 list::unsafeimplu32::new::UnsafeNew(DataType::U32).rust_shadowing(
+//                     stack,
+//                     _std_in.clone(),
+//                     _secret_in.clone(),
+//                     memory,
+//                 );
+//                 stack.pop().unwrap()
+//             }
+//         };
+
+//         // set length
+//         stack.push(list);
+//         stack.push(BFieldElement::new(number as u64));
+//         match self.list_type {
+//             ListType::Safe => {
+//                 list::safeimplu32::set_length::SafeSetLength(DataType::U32)
+//                     .rust_shadowing(stack, _std_in, _secret_in, memory);
+//             }
+//             ListType::Unsafe => {
+//                 list::unsafeimplu32::set_length::UnsafeSetLength(DataType::U32)
+//                     .rust_shadowing(stack, _std_in, _secret_in, memory);
+//             }
+//         }
+//         stack.pop();
+
+//         // store list to memory
+//         for (i, index) in indices.into_iter().enumerate() {
+//             set_element(
+//                 list,
+//                 i,
+//                 vec![BFieldElement::new(index as u64)],
+//                 memory,
+//                 DataType::U32.get_size(),
+//             );
+//         }
+
+//         stack.push(list);
+//     }
+// }
+
+// #[cfg(test)]
+// mod tests {
+
+//     use crate::{list::ListType, test_helpers::test_rust_equivalence_multiple_deprecated};
+
+//     use super::SampleIndices;
+
+//     #[test]
+//     fn new_prop_test() {
+//         test_rust_equivalence_multiple_deprecated(
+//             &SampleIndices {
+//                 list_type: ListType::Safe,
+//             },
+//             true,
+//         );
+//         test_rust_equivalence_multiple_deprecated(
+//             &SampleIndices {
+//                 list_type: ListType::Unsafe,
+//             },
+//             true,
+//         );
+//     }
+// }
+
+// #[cfg(test)]
+// mod benches {
+//     use super::*;
+//     use crate::snippet_bencher::bench_and_write;
+
+//     #[test]
+//     fn sample_indices_benchmark_safe() {
+//         bench_and_write(SampleIndices {
+//             list_type: ListType::Safe,
+//         });
+//     }
+
+//     #[test]
+//     fn sample_indices_benchmark_unsafe() {
+//         bench_and_write(SampleIndices {
+//             list_type: ListType::Unsafe,
+//         });
+//     }
+// }
+
+impl BasicSnippet for SampleIndices {
+    fn inputs(&self) -> Vec<(DataType, String)> {
+        vec![
+            (DataType::U32, "number".to_string()),
+            (DataType::U32, "upper_bound".to_string()),
+        ]
     }
 
-    fn input_field_names(&self) -> Vec<String>
-    where
-        Self: Sized,
-    {
-        vec!["number".to_string(), "upper_bound".to_string()]
+    fn outputs(&self) -> Vec<(DataType, String)> {
+        vec![(
+            DataType::List(Box::new(DataType::U32)),
+            "*indices".to_string(),
+        )]
     }
 
-    fn input_types(&self) -> Vec<crate::snippet::DataType> {
-        vec![DataType::U32, DataType::U32]
+    fn entrypoint(&self) -> String {
+        "sample_indices".to_string()
     }
 
-    fn output_types(&self) -> Vec<crate::snippet::DataType> {
-        vec![DataType::List(Box::new(DataType::U32))]
-    }
-
-    fn output_field_names(&self) -> Vec<String>
-    where
-        Self: Sized,
-    {
-        vec!["index_list".to_string()]
-    }
-
-    fn stack_diff(&self) -> isize
-    where
-        Self: Sized,
-    {
-        -1
-    }
-
-    fn function_code(&self, library: &mut crate::library::Library) -> String {
-        let entrypoint = self.entrypoint_name();
+    fn code(
+        &self,
+        library: &mut crate::library::Library,
+    ) -> Vec<triton_vm::instruction::LabelledInstruction> {
+        let entrypoint = self.entrypoint();
+        let main_loop = format!("{entrypoint}_main_loop");
+        let then_reduce_and_save = format!("{entrypoint}_then_reduce_and_save");
+        let then_reduce_and_save_special = format!("{entrypoint}_then_reduce_and_save_special");
+        let else_drop_tip = format!("{entrypoint}_else_drop_tip");
+        let else_drop_tip_special = format!("{entrypoint}_else_drop_tip_special");
         let new_list = match self.list_type {
             ListType::Safe => library.import(Box::new(SafeNew(DataType::U32))),
             ListType::Unsafe => library.import(Box::new(UnsafeNew(DataType::U32))),
         };
-        let set_length = match self.list_type {
-            ListType::Safe => library.import(Box::new(SafeSetLength(DataType::U32))),
-            ListType::Unsafe => library.import(Box::new(UnsafeSetLength(DataType::U32))),
+        let length = match self.list_type {
+            ListType::Safe => {
+                library.import(Box::new(list::safeimplu32::length::Length(DataType::U32)))
+            }
+            ListType::Unsafe => {
+                library.import(Box::new(list::unsafeimplu32::length::Length(DataType::U32)))
+            }
         };
-        let safety_offset = match self.list_type {
-            ListType::Safe => 2,
-            ListType::Unsafe => 1,
-        };
-        let minus_safety_offset = match self.list_type {
-            ListType::Safe => -2,
-            ListType::Unsafe => -1,
+        let push_element = match self.list_type {
+            ListType::Safe => library.import(Box::new(SafePush(DataType::U32))),
+            ListType::Unsafe => library.import(Box::new(UnsafePush(DataType::U32))),
         };
 
-        let process_top = format!("
-                // _ number upper_bound-1 address list_index prn^10
-                dup 10 // _ number upper_bound-1 address list_index prn^10 list_index
-                dup 14 // _ number upper_bound-1 address list_index prn^10 list_index number
-                eq // _ number upper_bound-1 address list_index prn^10 list_index==number
-                dup 1  // _ number upper_bound-1 address list_index prn^10 list_index==number prn0
-                push -1 eq  // _ number upper_bound-1 address list_index prn^10 list_index==number prn0==-1
-                add  // _ number upper_bound-1 address list_index prn^10 list_index==number||prn0==-1
-                push 0 eq // _ number upper_bound-1 address list_index prn^10 list_index!=number&&prn0!=-1
-                skiz call {entrypoint}_process_top_function_body
-                // _ number upper_bound-1 address list_index prn^10
-        ");
+        let if_can_sample = triton_asm! (
+            // BEFORE: _ prn number upper_bound *indices
+            // AFTER: _ prn number upper_bound *indices can_use
+            dup 0 call {length}         // _ prn number upper_bound *indices length
+            dup 3 eq                    // _ prn number upper_bound *indices length==number
+            push 0 eq                   // _ prn number upper_bound *indices length!=number
+            dup 4 push -1 eq            // _ prn number upper_bound *indices length!=number prn==max
+            push 0 eq                   // _ prn number upper_bound *indices length!=number prn!=max
+            mul                         // _ prn number upper_bound *indices length!=number&&prn!=max
+            push 1337 assert
+        );
 
-        let rotate_10 = "
-            swap 9
-            swap 8
-            swap 7
-            swap 6
-            swap 5
-            swap 4
-            swap 3
-            swap 2
-            swap 1"
-            .to_string();
-
-        format!(
-            "
+        triton_asm! (
             // BEFORE: _ number upper_bound
-            // AFTER: _ list
+            // AFTER: _ *indices
             {entrypoint}:
-                // assert power of two
-                dup 0 dup 0 // _ number upper_bound upper_bound upper_bound
-                push -1 add and // _ number upper_bound upper_bound&(upper_bound-1)
-                push 0 eq assert // asserts that upper_bound = 2^k for some k
-                push -1 add // _ number upper_bound-1
+                // allocate a large enough list
+                dup 1                   // _ number upper_bound length
+                call {new_list}         // _ number upper_bound *indices
 
-                // create list
-                dup 1 // _ number upper_bound-1 number
-                call {new_list} // _ number upper_bound-1 list
-                dup 2 //  _ number upper_bound-1 list number
-                call {set_length} // _ number upper_bound-1 list
-                push {safety_offset} add // _ number upper_bound-1 address
+                // prepare and call main while lop
+                swap 1                  // _ number *indices upper_bound
+                push -1 add             // _ number *indices upper_bound-1
+                swap 1                  // _ number upper_bound-1 *indices
+                call {main_loop}        // _ number upper_bound-1 *indices
 
-                // prepare and call loop
-                push 0 // _ number upper_bound-1 address 0
-                push 0 push 0 push 0 push 0 push 0 push 0 push 0 push 0 push 0 push 0
-                // _ number upper_bound-1 address list_index 0 0 0 0 0 0 0 0 0 0
-
-                sponge_squeeze // overwrite top 10 elements with fresh randomness
-                call {entrypoint}_loop // _ number upper_bound-1 address number prn9 prn8 prn7 prn6 prn5 prn4 prn3 prn2 prn1 prn0
-
-                // clean up stack
-                pop pop pop pop pop pop pop pop pop pop // _ number upper_bound-1 address number
-                pop // _ number upper_bound-1 address
-                swap 2  // _ address  upper_bound-1 number
-                pop pop // _ address
-                push {minus_safety_offset} add // _ list
-
+                // clean up and return
+                swap 2 pop pop
                 return
 
-            // INVARIANT: _ number upper_bound-1 list list_index prn9 prn8 prn7 prn6 prn5 prn4 prn3 prn2 prn1 prn0
-            {entrypoint}_loop:
-                // evaluate termination 
-                dup 13 // _ number upper_bound-1 address list_index prn9 prn8 prn7 prn6 prn5 prn4 prn3 prn2 prn1 prn0 number
-                dup 11 // _ number upper_bound-1 address list_index prn9 prn8 prn7 prn6 prn5 prn4 prn3 prn2 prn1 prn0 number list_index
-                eq // _ number upper_bound-1 address list_index prn9 prn8 prn7 prn6 prn5 prn4 prn3 prn2 prn1 prn0 number==list_index
+            // INVARIANT: _ number upper_bound-1 *indices
+            {main_loop}:
+                // evaluate termination condition
+                dup 0 call {length}     // _ number upper_bound-1 *indices length
+                dup 3 eq                // _ number upper_bound-1 *indices length==number
+                skiz return             // _ number upper_bound-1 *indices
 
-                skiz return // continue if unequal
-                // _ number upper_bound-1 address list_index  prn9 prn8 prn7 prn6 prn5 prn4 prn3 prn2 prn1 prn0
+                // we need to squeeze so squeeze
+                push 0 push 0 push 0 push 0 push 0
+                push 0 push 0 push 0 push 0 push 0
+                sponge_squeeze          // _ number upper_bound-1 *indices [prn]
 
-                {process_top}
-                {rotate_10}
+                // reject or reduce-and-store
+                dup 12 dup 12 dup 12    // _ number upper_bound-1 *indices [prn] number upper_bound-1 *indices
 
-                {process_top}
-                {rotate_10}
+                {&if_can_sample}
+                skiz call {then_reduce_and_save}
+                skiz call {else_drop_tip}
+                {&if_can_sample}
+                skiz call {then_reduce_and_save}
+                skiz call {else_drop_tip}
+                {&if_can_sample}
+                skiz call {then_reduce_and_save}
+                skiz call {else_drop_tip}
+                {&if_can_sample}
+                skiz call {then_reduce_and_save}
+                skiz call {else_drop_tip}
+                // push 1340 assert
+                {&if_can_sample}    // _ number upper_bound-1 *indices 1
+                push 1341 assert
+                skiz call {then_reduce_and_save_special}
+                skiz call {else_drop_tip_special}
 
-                {process_top}
-                {rotate_10}
+                {&if_can_sample}
+                skiz call {then_reduce_and_save}
+                skiz call {else_drop_tip}
+                {&if_can_sample}
+                skiz call {then_reduce_and_save}
+                skiz call {else_drop_tip}
+                {&if_can_sample}
+                skiz call {then_reduce_and_save}
+                skiz call {else_drop_tip}
+                {&if_can_sample}
+                skiz call {then_reduce_and_save}
+                skiz call {else_drop_tip}
+                {&if_can_sample}
+                skiz call {then_reduce_and_save}
+                skiz call {else_drop_tip}         // _ number upper_bound-1 *indices number upper_bound-1 *indices
 
-                {process_top}
-                {rotate_10}
 
-                {process_top}
-                {rotate_10}
+                dup 0 call {length} push 1338 assert
 
-                {process_top}
-                {rotate_10}
-
-                {process_top}
-                {rotate_10}
-
-                {process_top}
-                {rotate_10}
-
-                {process_top}
-                {rotate_10}
-
-                {process_top}
-                {rotate_10}
-
-                // _ number upper_bound-1 address list_index prn9 prn8 prn7 prn6 prn5 prn4 prn3 prn2 prn1 prn0
-
-                dup 10
-                push 0 eq
-                push 0 eq
-                assert // crash if list_index == 0
-
-                sponge_squeeze // overwrite top 10 elements with fresh randomness
-
+                // return to invariant and repeat
+                pop pop pop
                 recurse
-            
-            {entrypoint}_process_top_function_body:
-                dup 0  //  _ number upper_bound-1 address list_index prn^10 prn0
-                split //  _ number upper_bound-1 address list_index prn^10 hi lo
-                dup 13 //  _ number upper_bound-1 address list_index prn^10 hi lo address
-                dup 13 //  _ number upper_bound-1 address list_index prn^10 hi lo address list_index
-                add //  _ number upper_bound-1 address list_index prn^10 hi lo address+list_index
 
-                swap 1 //  _ number upper_bound-1 address list_index prn^10 hi address+list_index lo
-                dup 15 // _ number upper_bound-1 address list_index prn^10 hi address+list_index lo upper_bound-1
-                and // _ number upper_bound-1 address list_index prn^10 hi address+list_index (lo&(upper_bound-1))
+            // BEFORE: _ prn number upper_bound-1 *indices
+            // AFTER: _ number upper_bound-1 *indices 0
+            {then_reduce_and_save}:
+                swap 2 swap 3           // _ number *indices upper_bound-1 prn
+                split                   // _ number *indices upper_bound-1 hi lo
+                dup 2 and               // _ number *indices upper_bound-1 hi index
+                swap 1 pop              // _ number *indices upper_bound-1 index
 
-                write_mem  // _ number upper_bound-1 address list_index prn^10 hi address+list_index
-                pop pop // _ number upper_bound-1 address list_index prn^10
+                swap 1 swap 2 swap 1    // _ number upper_bound-1 *indices index
+                dup 1 swap 1            // _ number upper_bound-1 *indices *indices index
+                call {push_element}
 
-                swap 10
-                push 1 add
-                swap 10
-                // _ number upper_bound-1 address list_index+1 prn^10
+                push 0
                 return
-            "
+
+            // BEFORE: _ prn number upper_bound-1 *indices
+            // AFTER: _ number upper_bound-1 *indices 0
+            {then_reduce_and_save_special}:
+                swap 2 swap 3           // _ number *indices upper_bound-1 prn
+                split                   // _ number *indices upper_bound-1 hi lo
+                dup 2 and               // _ number *indices upper_bound-1 hi index
+                swap 1 pop              // _ number *indices upper_bound-1 index
+
+                swap 1 swap 2 swap 1    // _ number upper_bound-1 *indices index
+                dup 1 swap 1            // _ number upper_bound-1 *indices *indices index
+                call {push_element}     // _ number upper_bound-1 *indices
+
+                dup 0 call {length} push 1339 assert
+
+                push 0
+                return
+
+            // BEFORE: _ prn number upper_bound-1 *indices
+            // AFTER: _ number upper_bound-1 *indices
+            {else_drop_tip}:
+                swap 2 swap 3           // _ number *indices upper_bound-1 prn
+                pop swap 1              // _ number upper_bound-1 *indices
+                return
+
+            // BEFORE: _ prn number upper_bound-1 *indices
+            // AFTER: _ number upper_bound-1 *indices
+            {else_drop_tip_special}:
+                dup 0 call {length}
+                push 1337 assert
+                swap 2 swap 3           // _ number *indices upper_bound-1 prn
+                pop swap 1              // _ number upper_bound-1 *indices
+                return
         )
     }
+}
 
-    fn crash_conditions(&self) -> Vec<String>
-    where
-        Self: Sized,
-    {
-        vec![
-            "Number exceeds u32::MAX".to_string(),
-            "Upper bound is not a power of two".to_string(),
-        ]
-    }
-
-    fn gen_input_states(&self) -> Vec<crate::ExecutionState>
-    where
-        Self: Sized,
-    {
-        vec![
-            Self::test_state(0, 1 << 12),
-            Self::test_state(1, 1 << 12),
-            Self::test_state(10, 1 << 12),
-            Self::test_state(11, 1 << 12),
-            Self::test_state(45, 1 << 12),
-            Self::test_state(4, 1 << 31),
-        ]
-    }
-
-    fn common_case_input_state(&self) -> crate::ExecutionState
-    where
-        Self: Sized,
-    {
-        Self::test_state(45, 1 << 12)
-    }
-
-    fn worst_case_input_state(&self) -> crate::ExecutionState
-    where
-        Self: Sized,
-    {
-        Self::test_state(160, 1 << 23)
-    }
-
-    fn rust_shadowing(
+impl Procedure for SampleIndices {
+    fn rust_shadow(
         &self,
-        stack: &mut Vec<triton_vm::BFieldElement>,
-        _std_in: Vec<triton_vm::BFieldElement>,
-        _secret_in: Vec<triton_vm::BFieldElement>,
-        memory: &mut std::collections::HashMap<triton_vm::BFieldElement, triton_vm::BFieldElement>,
-    ) where
-        Self: Sized,
-    {
+        stack: &mut Vec<BFieldElement>,
+        memory: &mut HashMap<BFieldElement, BFieldElement>,
+        _nondeterminism: &NonDeterminism<BFieldElement>,
+        _public_input: &[BFieldElement],
+        sponge_state: &mut VmHasherState,
+    ) -> Vec<BFieldElement> {
+        // collect upper bound and number from stack
         let upper_bound = stack.pop().unwrap().value() as u32;
         let number = stack.pop().unwrap().value() as usize;
 
-        assert!(
-            is_power_of_two(upper_bound),
-            "Upper bound {upper_bound} must be a power of two"
+        println!("sampling {number} indices between 0 and {upper_bound}");
+        println!(
+            "sponge state before: {}",
+            sponge_state.state.iter().map(|b| b.value()).join(",")
         );
-
-        // helper functions
-        let set_element = match self.list_type {
-            ListType::Safe => rust_shadowing_helper_functions::safe_list::safe_list_set,
-            ListType::Unsafe => rust_shadowing_helper_functions::unsafe_list::unsafe_list_set,
-        };
 
         // sample indices
-        let mut indices: Vec<u32> = vec![];
-        let mut sponge_state = VmHasherState::new(Domain::VariableLength);
-        let mut squeezed = vec![];
-        while indices.len() < number {
-            if squeezed.is_empty() {
-                squeezed = Tip5::squeeze(&mut sponge_state)
-                    .into_iter()
-                    .rev()
-                    .collect_vec();
-            }
+        let indices = VmHasher::sample_indices(sponge_state, upper_bound, number);
 
-            let element = squeezed.pop().unwrap();
-            if element != BFieldElement::new(BFieldElement::MAX) {
-                indices.push(element.value() as u32 % upper_bound);
-            }
-        }
+        // allocate memory for (unsafe) list
+        let list_pointer =
+            rust_shadowing_helper_functions::dyn_malloc::dynamic_allocator(1 + number, memory);
+        rust_shadowing_helper_functions::unsafe_list::unsafe_list_new(list_pointer, memory);
 
-        // double-shadow with twenty-first
-        let twenty_first_indices = VmHasher::sample_indices(
-            &mut VmHasherState::new(Domain::VariableLength),
-            upper_bound,
-            number,
-        );
-        assert_eq!(twenty_first_indices, indices);
-
-        // create list object
-        let capacity = number;
-        let list = match self.list_type {
-            ListType::Safe => {
-                // Push capacity to stack
-                stack.push(BFieldElement::new(capacity as u64));
-                list::safeimplu32::new::SafeNew(DataType::U32).rust_shadowing(
-                    stack,
-                    _std_in.clone(),
-                    _secret_in.clone(),
-                    memory,
-                );
-                stack.pop().unwrap()
-            }
-            ListType::Unsafe => {
-                stack.push(BFieldElement::new(capacity as u64));
-                list::unsafeimplu32::new::UnsafeNew(DataType::U32).rust_shadowing(
-                    stack,
-                    _std_in.clone(),
-                    _secret_in.clone(),
-                    memory,
-                );
-                stack.pop().unwrap()
-            }
-        };
-
-        // set length
-        stack.push(list);
-        stack.push(BFieldElement::new(number as u64));
-        match self.list_type {
-            ListType::Safe => {
-                list::safeimplu32::set_length::SafeSetLength(DataType::U32)
-                    .rust_shadowing(stack, _std_in, _secret_in, memory);
-            }
-            ListType::Unsafe => {
-                list::unsafeimplu32::set_length::UnsafeSetLength(DataType::U32)
-                    .rust_shadowing(stack, _std_in, _secret_in, memory);
-            }
-        }
-        stack.pop();
-
-        // store list to memory
-        for (i, index) in indices.into_iter().enumerate() {
-            set_element(
-                list,
-                i,
-                vec![BFieldElement::new(index as u64)],
+        // store all indices
+        for index in indices.iter() {
+            rust_shadowing_helper_functions::unsafe_list::unsafe_list_push(
+                list_pointer,
+                vec![BFieldElement::new(*index as u64)],
                 memory,
-                DataType::U32.get_size(),
+                1,
             );
         }
+        println!(
+            "sponge state after: {}",
+            sponge_state.state.iter().map(|b| b.value()).join(",")
+        );
 
-        stack.push(list);
+        // populate the stack with the list pointer
+        stack.push(list_pointer);
+
+        vec![]
+    }
+
+    fn pseudorandom_initial_state(
+        &self,
+        seed: [u8; 32],
+        bench_case: Option<crate::snippet_bencher::BenchmarkCase>,
+    ) -> (
+        Vec<BFieldElement>,
+        HashMap<BFieldElement, BFieldElement>,
+        NonDeterminism<BFieldElement>,
+        Vec<BFieldElement>,
+        VmHasherState,
+    ) {
+        let mut rng: StdRng = SeedableRng::from_seed(seed);
+        let number = if let Some(case) = bench_case {
+            match case {
+                crate::snippet_bencher::BenchmarkCase::CommonCase => 45,
+                crate::snippet_bencher::BenchmarkCase::WorstCase => 105,
+            }
+        } else {
+            rng.gen_range(0..20)
+        };
+        let upper_bound = 1 << rng.gen_range(0..20);
+
+        let mut stack = empty_stack();
+        stack.push(BFieldElement::new(number as u64));
+        stack.push(BFieldElement::new(upper_bound as u64));
+
+        let memory: HashMap<BFieldElement, BFieldElement> = HashMap::new();
+
+        let nondeterminism = NonDeterminism::new(vec![]);
+        let public_input: Vec<BFieldElement> = vec![];
+        let state = VmHasherState {
+            state: rng.gen::<[BFieldElement; STATE_SIZE]>(),
+        };
+
+        (stack, memory, nondeterminism, public_input, state)
     }
 }
 
 #[cfg(test)]
-mod tests {
-
-    use crate::{list::ListType, test_helpers::test_rust_equivalence_multiple_deprecated};
+mod test {
+    use crate::{list::ListType, procedure::ShadowedProcedure, snippet::RustShadow};
 
     use super::SampleIndices;
 
     #[test]
-    fn new_prop_test() {
-        test_rust_equivalence_multiple_deprecated(
-            &SampleIndices {
-                list_type: ListType::Safe,
-            },
-            true,
-        );
-        test_rust_equivalence_multiple_deprecated(
-            &SampleIndices {
-                list_type: ListType::Unsafe,
-            },
-            true,
-        );
+    fn test() {
+        ShadowedProcedure::new(SampleIndices {
+            list_type: ListType::Unsafe,
+        })
+        .test();
     }
 }
 
 #[cfg(test)]
-mod benches {
-    use super::*;
-    use crate::snippet_bencher::bench_and_write;
+mod bench {
+    use crate::{list::ListType, procedure::ShadowedProcedure, snippet::RustShadow};
+
+    use super::SampleIndices;
 
     #[test]
-    fn sample_indices_benchmark_safe() {
-        bench_and_write(SampleIndices {
-            list_type: ListType::Safe,
-        });
-    }
-
-    #[test]
-    fn sample_indices_benchmark_unsafe() {
-        bench_and_write(SampleIndices {
+    fn bench() {
+        ShadowedProcedure::new(SampleIndices {
             list_type: ListType::Unsafe,
-        });
+        })
+        .bench();
     }
 }

--- a/tasm-lib/src/lib.rs
+++ b/tasm-lib/src/lib.rs
@@ -7,6 +7,7 @@ use anyhow::bail;
 use itertools::Itertools;
 use library::Library;
 use memory::dyn_malloc;
+use memory::dyn_malloc::DYN_MALLOC_ADDRESS;
 use num_traits::Zero;
 use snippet::BasicSnippet;
 use snippet::DeprecatedSnippet;
@@ -26,8 +27,6 @@ use twenty_first::shared_math::tip5::{self, Tip5};
 use triton_vm::op_stack::NUM_OP_STACK_REGISTERS;
 use triton_vm::vm::VMState;
 use twenty_first::shared_math::b_field_element::BFieldElement;
-
-use crate::memory::dyn_malloc::DYN_MALLOC_ADDRESS;
 
 pub mod algorithm;
 pub mod arithmetic;
@@ -178,8 +177,7 @@ pub fn execute_bench_deprecated(
 
     // Prepend to program the initial stack values such that stack is in the expected
     // state when program logic is executed
-    let prep: Vec<LabelledInstruction> =
-        state_preparation_code(stack, memory, initilialize_dynamic_allocator_to);
+    let prep: Vec<LabelledInstruction> = stack_preparation_code(stack);
 
     // Add the program after the stack initialization has been performed
     // Find the length of code used for setup. This length does not count towards execution length
@@ -302,14 +300,31 @@ pub fn execute_test(
         }
     }
 
+    let maybe_highest_address = nondeterminism.ram.keys().map(|b| b.value()).max();
+    if let Some(initial_value) = initilialize_dynamic_allocator_to {
+        if let Some(highest_address) = maybe_highest_address {
+            if initial_value as u64 > highest_address {
+                nondeterminism.ram.insert(
+                    BFieldElement::new(DYN_MALLOC_ADDRESS as u64),
+                    BFieldElement::new(initial_value as u64),
+                );
+            } else {
+                nondeterminism.ram.insert(
+                    BFieldElement::new(DYN_MALLOC_ADDRESS as u64),
+                    BFieldElement::new(highest_address + 1),
+                );
+            }
+        } else {
+            nondeterminism.ram.insert(
+                BFieldElement::new(DYN_MALLOC_ADDRESS as u64),
+                BFieldElement::new(initial_value as u64),
+            );
+        }
+    };
+
     // produce standalone program that starts off arranging
     // the state as we expect
-    let program = program_with_state_preparation(
-        code,
-        stack,
-        nondeterminism,
-        initilialize_dynamic_allocator_to,
-    );
+    let program = prepend_state_preparation(code, stack);
 
     // run VM
     let maybe_final_state =
@@ -368,40 +383,16 @@ pub fn execute_test(
 }
 
 /// Given an assembled and linked program (represented as a list of
-/// `LabelledInstruction`s), and given a description of the stack and
-/// initial dynamic allocator value, add to the program code for putting
-/// the stack in the right order. Also: modify the nondeterminism so
-/// that the initial dynamic allocator value is correct.
-pub fn program_with_state_preparation(
-    code: &[LabelledInstruction],
-    stack: &[BFieldElement],
-    nondeterminism: &mut NonDeterminism<BFieldElement>,
-    initilialize_dynamic_allocator_to: Option<usize>,
-) -> Program {
-    // Ensure that the dynamic allocator is initialized such that it does not overwrite
-    // any statically allocated memory, if the caller requests this.
-    if let Some(dyn_malloc_initial_value) = initilialize_dynamic_allocator_to {
-        if let Some(v) = nondeterminism
-            .ram
-            .get(&BFieldElement::new(DYN_MALLOC_ADDRESS as u64))
-        {
-            assert_eq!(v.value() as usize, dyn_malloc_initial_value, "nondeterminism already specifies dynamic allocator value {} =/= {} at address zero", v.value(), dyn_malloc_initial_value);
-        } else {
-            nondeterminism.ram.insert(
-                BFieldElement::new(DYN_MALLOC_ADDRESS as u64),
-                BFieldElement::new(dyn_malloc_initial_value as u64),
-            );
-        }
-    }
-
+/// `LabelledInstruction`s), and given a description of the stack,
+/// add to the program code for putting
+/// the stack in the right order.
+pub fn prepend_state_preparation(code: &[LabelledInstruction], stack: &[BFieldElement]) -> Program {
     // Prepend to program the initial stack values such that stack is in the expected
     // state when program logic is executed.
     // The next function call does something analogous for memory but it
     // predates the option of setting the initial memory value through
     // nondeterminism. So we just feed it empty memory.
-    let memory = HashMap::new();
-    let prep: Vec<LabelledInstruction> =
-        state_preparation_code(stack, &memory, initilialize_dynamic_allocator_to);
+    let prep: Vec<LabelledInstruction> = stack_preparation_code(stack);
     let mut executed_code = prep;
 
     // Construct the whole program (inclusive setup) to be run
@@ -454,35 +445,10 @@ pub fn execute_with_terminal_state<'a>(
 }
 
 /// Produce the code to set the stack and memory into a certain state
-fn state_preparation_code(
-    stack: &[BFieldElement],
-    memory: &HashMap<BFieldElement, BFieldElement>,
-    initilialize_dynamic_allocator_to: Option<usize>,
-) -> Vec<LabelledInstruction> {
+fn stack_preparation_code(stack: &[BFieldElement]) -> Vec<LabelledInstruction> {
     let mut state_preparation_code = Vec::default();
     for element in stack.iter().skip(NUM_OP_STACK_REGISTERS) {
         state_preparation_code.push(triton_instr!(push element.value()));
-    }
-
-    // Add all the initial memory to the VM
-    for (address, value) in memory.iter() {
-        // Prepare stack for writing
-        state_preparation_code.push(triton_instr!(push address.value()));
-        state_preparation_code.push(triton_instr!(push value.value()));
-
-        // Write value to memory
-        state_preparation_code.push(triton_instr!(write_mem));
-
-        // Clean stack after writing to memory
-        state_preparation_code.push(triton_instr!(pop));
-    }
-
-    // Ensure that the dynamic allocator is initialized such that it does not overwrite
-    // any statically allocated memory, if the caller requests this.
-    if let Some(dyn_malloc_initial_value) = initilialize_dynamic_allocator_to {
-        state_preparation_code.append(&mut dyn_malloc::DynMalloc::get_initialization_code(
-            dyn_malloc_initial_value.try_into().unwrap(),
-        ));
     }
 
     state_preparation_code

--- a/tasm-lib/src/linker.rs
+++ b/tasm-lib/src/linker.rs
@@ -6,7 +6,7 @@ use triton_vm::{
 };
 
 use crate::{
-    library::Library, prove_and_verify, snippet::BasicSnippet, state_preparation_code,
+    library::Library, prove_and_verify, snippet::BasicSnippet, stack_preparation_code,
     ExecutionResult,
 };
 
@@ -43,8 +43,7 @@ pub fn execute_bench(
 ) -> ExecutionResult {
     // Prepend to program the initial stack values and initial memory values
     // such that stack is in the expected state when program logic is executed
-    let prep: Vec<LabelledInstruction> =
-        state_preparation_code(stack, memory, initilialize_dynamic_allocator_to);
+    let prep: Vec<LabelledInstruction> = stack_preparation_code(stack);
 
     // Add the program after the stack initialization has been performed
     // Find the length of code used for setup. This length does not count towards

--- a/tasm-lib/src/list/contiguous_list/get_length.rs
+++ b/tasm-lib/src/list/contiguous_list/get_length.rs
@@ -7,6 +7,7 @@ use twenty_first::shared_math::{bfield_codec::BFieldCodec, other::random_element
 
 use crate::{
     empty_stack,
+    memory::dyn_malloc::DYN_MALLOC_ADDRESS,
     snippet::{DataType, DeprecatedSnippet},
     Digest, ExecutionState,
 };
@@ -67,6 +68,7 @@ impl GetLength {
             memory.insert(address, word);
             address.increment();
         }
+        memory.insert(BFieldElement::new(DYN_MALLOC_ADDRESS as u64), address);
 
         ExecutionState::with_stack_and_memory(stack, memory, 1)
     }

--- a/tasm-lib/src/procedure.rs
+++ b/tasm-lib/src/procedure.rs
@@ -108,7 +108,7 @@ impl<P: Procedure + 'static> RustShadow for ShadowedProcedure<P> {
                 procedure.borrow().pseudorandom_initial_state(seed, None);
 
             let init_stack = stack.to_vec();
-            let words_statically_allocated = 0;
+            let words_statically_allocated = 1;
 
             let rust = rust_final_state(
                 self,

--- a/tasm-lib/src/recufier/fri_verify.rs
+++ b/tasm-lib/src/recufier/fri_verify.rs
@@ -727,14 +727,6 @@ impl BasicSnippet for FriVerify {
                 // sample "A" indices
                 call {sample_indices}       // _ *proof_stream *fri_verify num_rounds last_round_max_degree 0 *roots *alphas *proof_stream *indices
 
-                read_mem swap 1 push 1 add
-                read_mem swap 1 push 1 add
-                read_mem swap 1 push 1 add
-                read_mem swap 1 push 1 add
-                read_mem swap 1 push 1 add
-                read_mem swap 1 push 1 add
-
-                push 1337 assert
                 // get largest tree height
                 dup 7                       // _ *proof_stream *fri_verify num_rounds last_round_max_degree 0 *roots *alphas *proof_stream *indices *fri_verify
                 {&domain_length}            // _ *proof_stream *fri_verify num_rounds last_round_max_degree 0 *roots *alphas *proof_stream *indices *domain_length
@@ -1122,6 +1114,8 @@ mod test {
         rust_object
             .iter()
             .zip(tasm_object.iter())
-            .for_each(|(r, t)| assert_eq!(r, t));
+            .for_each(|(r, t)| {
+                assert_eq!(r, t, "returned lists of indices and leafs do not match")
+            });
     }
 }

--- a/tasm-lib/src/recufier/merkle_verify.rs
+++ b/tasm-lib/src/recufier/merkle_verify.rs
@@ -220,7 +220,7 @@ mod tests {
     use crate::algorithm::ShadowedAlgorithm;
     use crate::linker::link_for_isolated_run;
     use crate::snippet::RustShadow;
-    use crate::{execute_with_terminal_state, program_with_state_preparation, VmHasherState};
+    use crate::{execute_with_terminal_state, prepend_state_preparation, VmHasherState};
 
     use super::MerkleVerify;
 
@@ -289,7 +289,7 @@ mod tests {
 
             // run tvm
             let code = link_for_isolated_run(Rc::new(RefCell::new(MerkleVerify)), 0);
-            let program = program_with_state_preparation(&code, &stack, &mut nondeterminism, None);
+            let program = prepend_state_preparation(&code, &stack);
             let tvm_result =
                 execute_with_terminal_state(&program, &stdin, &mut nondeterminism, None);
             if let Ok(result) = &tvm_result {

--- a/tasm-lib/src/recufier/proof_stream/dequeue.rs
+++ b/tasm-lib/src/recufier/proof_stream/dequeue.rs
@@ -266,8 +266,8 @@ mod test {
     use crate::{
         empty_stack, execute_with_terminal_state,
         linker::link_for_isolated_run,
+        prepend_state_preparation,
         procedure::{Procedure, ShadowedProcedure},
-        program_with_state_preparation,
         snippet::RustShadow,
         test_helpers::test_rust_equivalence_given_complete_state,
         VmHasherState,
@@ -365,7 +365,7 @@ mod test {
 
             // run tvm
             let code = link_for_isolated_run(Rc::new(RefCell::new(dequeue.clone())), 0);
-            let program = program_with_state_preparation(&code, &stack, &mut nondeterminism, None);
+            let program = prepend_state_preparation(&code, &stack);
             let tvm_result =
                 execute_with_terminal_state(&program, &stdin, &mut nondeterminism, None);
             println!("tvm_result: {tvm_result:?}");

--- a/tasm-lib/src/recufier/verify_authentication_paths_for_leaf_and_index_list.rs
+++ b/tasm-lib/src/recufier/verify_authentication_paths_for_leaf_and_index_list.rs
@@ -263,7 +263,7 @@ mod test {
         execute_with_terminal_state,
         linker::link_for_isolated_run,
         list::ListType,
-        program_with_state_preparation,
+        prepend_state_preparation,
         snippet::RustShadow,
         VmHasherState,
     };
@@ -340,7 +340,7 @@ mod test {
             // run tvm
             let code = link_for_isolated_run(Rc::new(RefCell::new(vap4lail.clone())), 0);
             nondeterminism.ram = memory;
-            let program = program_with_state_preparation(&code, &stack, &mut nondeterminism, None);
+            let program = prepend_state_preparation(&code, &stack);
             let tvm_result =
                 execute_with_terminal_state(&program, &stdin, &mut nondeterminism, None);
             if let Ok(result) = &tvm_result {

--- a/tasm-lib/src/snippet.rs
+++ b/tasm-lib/src/snippet.rs
@@ -14,7 +14,7 @@ use twenty_first::shared_math::b_field_element::BFieldElement;
 
 use crate::execute_with_terminal_state;
 use crate::library::Library;
-use crate::program_with_state_preparation;
+use crate::prepend_state_preparation;
 use crate::test_helpers::test_rust_equivalence_given_execution_state_deprecated;
 use crate::VmHasherState;
 use crate::{execute_bench_deprecated, ExecutionResult, VmOutputState, DIGEST_LENGTH};
@@ -388,8 +388,7 @@ pub trait DeprecatedSnippet {
         let mut nondeterminism = NonDeterminism::new(secret_in).with_ram(memory.clone());
 
         let code = self.link_for_isolated_run(words_allocated);
-        let program =
-            program_with_state_preparation(&code, stack, &mut nondeterminism, words_allocated);
+        let program = prepend_state_preparation(&code, stack);
         let tvm_result = execute_with_terminal_state(&program, &std_in, &mut nondeterminism, None);
 
         let maybe_final_state = tvm_result.map(|st| VmOutputState {

--- a/tasm-lib/src/structure/tasm_object.rs
+++ b/tasm-lib/src/structure/tasm_object.rs
@@ -805,7 +805,7 @@ mod test {
         empty_stack, execute_with_terminal_state, io,
         library::Library,
         list::unsafeimplu32::length::Length,
-        memory, program_with_state_preparation,
+        memory, prepend_state_preparation,
         snippet::{DataType, DeprecatedSnippet, InputSource},
         structure::tasm_object::{load_to_memory, TasmObject},
         test_helpers::test_rust_equivalence_multiple_deprecated,
@@ -1143,12 +1143,7 @@ mod test {
 
             {&library_code}
         );
-        let program = program_with_state_preparation(
-            &instructions,
-            &stack,
-            &mut nondeterminism,
-            Some(words_statically_allocated),
-        );
+        let program = prepend_state_preparation(&instructions, &stack);
 
         // run VM; get stack at end
         let final_state =

--- a/tasm-lib/src/structure/tasm_object.rs
+++ b/tasm-lib/src/structure/tasm_object.rs
@@ -796,7 +796,6 @@ mod test {
     use std::collections::HashMap;
 
     use itertools::Itertools;
-    use num_traits::Zero;
     use rand::{rngs::StdRng, thread_rng, Rng, SeedableRng};
     use triton_vm::{proof_item::FriResponse, triton_asm, BFieldElement, NonDeterminism};
     use twenty_first::shared_math::{bfield_codec::BFieldCodec, x_field_element::XFieldElement};
@@ -805,7 +804,8 @@ mod test {
         empty_stack, execute_with_terminal_state, io,
         library::Library,
         list::unsafeimplu32::length::Length,
-        memory, prepend_state_preparation,
+        memory::{self},
+        prepend_state_preparation,
         snippet::{DataType, DeprecatedSnippet, InputSource},
         structure::tasm_object::{load_to_memory, TasmObject},
         test_helpers::test_rust_equivalence_multiple_deprecated,
@@ -1120,12 +1120,6 @@ mod test {
         // initialize memory and stack
         let mut memory: HashMap<BFieldElement, BFieldElement> = HashMap::new();
         let address = load_to_memory(&mut memory, fri_response);
-        let words_statically_allocated = if let Some(allocator) = memory.get(&BFieldElement::zero())
-        {
-            allocator.value() as usize
-        } else {
-            1
-        };
         let mut stack = empty_stack();
         stack.push(address);
         let mut nondeterminism = NonDeterminism::new(vec![]).with_ram(memory);

--- a/tasm-lib/src/test_helpers.rs
+++ b/tasm-lib/src/test_helpers.rs
@@ -312,7 +312,7 @@ mod test {
     use triton_vm::{BFieldElement, NonDeterminism};
     use twenty_first::shared_math::tip5::DIGEST_LENGTH;
 
-    use crate::{empty_stack, hashing::sample_indices::SampleIndices, list::ListType};
+    use crate::{empty_stack, hashing::hash_varlen::HashVarlen};
 
     use super::test_rust_equivalence_given_complete_state_deprecated;
 
@@ -322,9 +322,8 @@ mod test {
     /// to these first five elements. This unit test tests this.
     #[test]
     fn test_program_hash_ignored() {
-        let snippet_struct = SampleIndices {
-            list_type: ListType::Safe,
-        };
+        // arbitrary snippet that does something related to hashing
+        let snippet_struct = HashVarlen;
         let mut stack = empty_stack();
         stack.push(BFieldElement::new(45u64));
         stack.push(BFieldElement::new(1u64 << 12));
@@ -392,7 +391,7 @@ pub fn tasm_final_state<T: RustShadow>(
     nondeterminism: &NonDeterminism<BFieldElement>,
     memory: &HashMap<BFieldElement, BFieldElement>,
     sponge_state: &VmHasherState,
-    _words_statically_allocated: usize,
+    words_statically_allocated: usize,
 ) -> VmOutputState {
     // run tvm
     link_and_run_tasm_for_test(
@@ -402,7 +401,7 @@ pub fn tasm_final_state<T: RustShadow>(
         &mut nondeterminism.clone(),
         &mut memory.clone(),
         Some(sponge_state.to_owned()),
-        0,
+        words_statically_allocated,
     )
 }
 
@@ -494,7 +493,13 @@ pub fn verify_stack_growth<T: RustShadow>(
 }
 
 pub fn verify_sponge_equivalence(a: &VmHasherState, b: &VmHasherState) {
-    assert_eq!(a.state, b.state, "sponge states are different");
+    assert_eq!(
+        a.state,
+        b.state,
+        "sponge states are different:\nleft: {}\n:right: {}",
+        a.state.iter().map(|b| b.value()).join(","),
+        b.state.iter().map(|b| b.value()).join(",")
+    );
 }
 
 #[allow(dead_code)]
@@ -555,9 +560,25 @@ pub fn link_and_run_tasm_for_test<T: RustShadow>(
     nondeterminism: &mut NonDeterminism<BFieldElement>,
     memory: &mut HashMap<BFieldElement, BFieldElement>,
     maybe_sponge_state: Option<VmHasherState>,
-    _words_statically_allocated: usize,
+    words_statically_allocated: usize,
 ) -> VmOutputState {
-    let code = link_for_isolated_run(snippet_struct, 0);
+    let code = link_for_isolated_run(snippet_struct, words_statically_allocated);
+
+    let maybe_highest_address = nondeterminism
+        .ram
+        .keys()
+        .chain(memory.keys())
+        .map(|b| b.value())
+        .max();
+    let allocator_initial_value = if let Some(highest_address) = maybe_highest_address {
+        if highest_address > words_statically_allocated as u64 {
+            highest_address + 1
+        } else {
+            words_statically_allocated as u64
+        }
+    } else {
+        words_statically_allocated as u64
+    };
 
     execute_test(
         &code,
@@ -567,7 +588,7 @@ pub fn link_and_run_tasm_for_test<T: RustShadow>(
         nondeterminism,
         memory,
         maybe_sponge_state,
-        None,
+        Some(allocator_initial_value as usize),
     )
 }
 


### PR DESCRIPTION
The sponge state was mismatched between the tasm code and the rust shadow for `fri_verify`. This fix:
 - [x] replaces the snippet `SampleIndices` with a new version that implements the non-deprecated `BasicSnippet` and `Procedure`. (The latter gives access to the sponge state.)
 - [x] Simplifies some of the test framework. In particular, state preparation is decoupled from memory and initial memory is entirely supplied through non-determinism.
 - [x] Fixes errors downstream from this simplification.