### PR TITLE
add githuh ci workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,47 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+name: Rust
+
+jobs:
+  runner-matrix:
+    name: format, lint, test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings
+
+      - name: Run cargo test without benches
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: -- --skip benches


### PR DESCRIPTION
I just copied the github CI workflow from twenty-first repo.   Hopefully it will work?  I don't see anything twenty-first specific in it.

But then I have near zero knowledge of how github CI works.

So I don't know if there is a manual step required in the UI to enable the actions, or what.   And I'm unsure how to test.

anyway, I hope it is helpful.