### PR TITLE
update worst case benchmark for `HashVarlen`

### DIFF
--- a/tasm-lib/benchmarks/tasm_hashing_hash_varlen.json
+++ b/tasm-lib/benchmarks/tasm_hashing_hash_varlen.json
@@ -8,9 +8,9 @@
   },
   {
     "name": "tasm_hashing_hash_varlen",
-    "clock_cycle_count": 1366,
-    "hash_table_height": 703,
-    "u32_table_height": 16,
+    "clock_cycle_count": 110758,
+    "hash_table_height": 55399,
+    "u32_table_height": 23,
     "case": "WorstCase"
   }
 ]

--- a/tasm-lib/src/hashing/hash_varlen.rs
+++ b/tasm-lib/src/hashing/hash_varlen.rs
@@ -109,7 +109,7 @@ impl DeprecatedSnippet for HashVarlen {
     }
 
     fn worst_case_input_state(&self) -> ExecutionState {
-        Self::random_memory_state_read_k(1000)
+        Self::random_memory_state_read_k(92160)
     }
 
     fn rust_shadowing(


### PR DESCRIPTION
The new number, 92160, comes from the maximum number of indices in the mutator set's active window.