### PR TITLE
Separate FRI parameters from FRI snippet

### DIFF
--- a/tasm-lib/src/exported_snippets.rs
+++ b/tasm-lib/src/exported_snippets.rs
@@ -78,7 +78,6 @@ use crate::mmr::verify_from_secret_in::MmrVerifyLeafMembershipFromSecretIn;
 use crate::neptune::mutator_set::commit::Commit;
 use crate::neptune::mutator_set::get_swbf_indices::GetSwbfIndices;
 use crate::other_snippets::bfe_add::BfeAdd;
-use crate::recufier::fri_verify::FriSnippet;
 use crate::recufier::merkle_verify::MerkleVerify;
 use crate::recufier::proof_stream::dequeue_next_as::DequeueNextAs;
 use crate::recufier::read_and_verify_own_program_digest_from_std_in::ReadAndVerifyOwnProgramDigestFromStdIn;
@@ -207,8 +206,8 @@ pub fn name_to_snippet(fn_name: &str) -> Box<dyn BasicSnippet> {
 
         // Hashing -> algebraic hasher trait
         "tasm_hashing_algebraic_hasher_hash_varlen" => Box::new(algebraic_hasher::hash_varlen::HashVarlen),
-        "tasm_hashing_algebraic_hasher_sample_indices_safeimplu32" => Box::new(algebraic_hasher::sample_indices::SampleIndices{list_type: ListType::Safe}),
-        "tasm_hashing_algebraic_hasher_sample_indices_unsafeimplu32" => Box::new(algebraic_hasher::sample_indices::SampleIndices{list_type: ListType::Unsafe}),
+        "tasm_hashing_algebraic_hasher_sample_indices_safeimplu32" => Box::new(algebraic_hasher::sample_indices::SampleIndices { list_type: ListType::Safe }),
+        "tasm_hashing_algebraic_hasher_sample_indices_unsafeimplu32" => Box::new(algebraic_hasher::sample_indices::SampleIndices { list_type: ListType::Unsafe }),
         "tasm_hashing_algebraic_hasher_sample_scalars" => Box::new(algebraic_hasher::sample_scalars::SampleScalars),
 
         // Hashing -> Sponge hasher trait
@@ -281,13 +280,13 @@ pub fn name_to_snippet(fn_name: &str) -> Box<dyn BasicSnippet> {
             input_source: InputSource::StdIn,
         }),
 
-        "tasm_io_write_to_stdout___bool" => Box::new(WriteToStdout{ data_type: DataType::Bool}),
-        "tasm_io_write_to_stdout___u32" => Box::new(WriteToStdout{ data_type: DataType::U32}),
-        "tasm_io_write_to_stdout___u64" => Box::new(WriteToStdout{ data_type: DataType::U64}),
-        "tasm_io_write_to_stdout___u128" => Box::new(WriteToStdout{ data_type: DataType::U128}),
-        "tasm_io_write_to_stdout___bfe" => Box::new(WriteToStdout{ data_type: DataType::Bfe }),
-        "tasm_io_write_to_stdout___xfe" => Box::new(WriteToStdout{ data_type: DataType::Xfe }),
-        "tasm_io_write_to_stdout___digest" => Box::new(WriteToStdout{ data_type: DataType::Digest}),
+        "tasm_io_write_to_stdout___bool" => Box::new(WriteToStdout { data_type: DataType::Bool }),
+        "tasm_io_write_to_stdout___u32" => Box::new(WriteToStdout { data_type: DataType::U32 }),
+        "tasm_io_write_to_stdout___u64" => Box::new(WriteToStdout { data_type: DataType::U64 }),
+        "tasm_io_write_to_stdout___u128" => Box::new(WriteToStdout { data_type: DataType::U128 }),
+        "tasm_io_write_to_stdout___bfe" => Box::new(WriteToStdout { data_type: DataType::Bfe }),
+        "tasm_io_write_to_stdout___xfe" => Box::new(WriteToStdout { data_type: DataType::Xfe }),
+        "tasm_io_write_to_stdout___digest" => Box::new(WriteToStdout { data_type: DataType::Digest }),
 
         // safe lists
         "tasm_list_safeimplu32_get_element___bool" => Box::new(SafeGet { data_type: DataType::Bool }),
@@ -297,12 +296,12 @@ pub fn name_to_snippet(fn_name: &str) -> Box<dyn BasicSnippet> {
         "tasm_list_safeimplu32_get_element___xfe" => Box::new(SafeGet { data_type: DataType::Xfe }),
         "tasm_list_safeimplu32_get_element___digest" => Box::new(SafeGet { data_type: DataType::Digest }),
 
-        "tasm_list_safeimplu32_pop___bool" => Box::new(SafePop { data_type: DataType::Bool } ),
-        "tasm_list_safeimplu32_pop___u32" => Box::new(SafePop { data_type: DataType::U32 } ),
-        "tasm_list_safeimplu32_pop___u64" => Box::new(SafePop { data_type: DataType::U64 } ),
-        "tasm_list_safeimplu32_pop___bfe" => Box::new(SafePop { data_type: DataType::Bfe } ),
-        "tasm_list_safeimplu32_pop___xfe" => Box::new(SafePop { data_type: DataType::Xfe } ),
-        "tasm_list_safeimplu32_pop___digest" => Box::new(SafePop { data_type: DataType::Digest } ),
+        "tasm_list_safeimplu32_pop___bool" => Box::new(SafePop { data_type: DataType::Bool }),
+        "tasm_list_safeimplu32_pop___u32" => Box::new(SafePop { data_type: DataType::U32 }),
+        "tasm_list_safeimplu32_pop___u64" => Box::new(SafePop { data_type: DataType::U64 }),
+        "tasm_list_safeimplu32_pop___bfe" => Box::new(SafePop { data_type: DataType::Bfe }),
+        "tasm_list_safeimplu32_pop___xfe" => Box::new(SafePop { data_type: DataType::Xfe }),
+        "tasm_list_safeimplu32_pop___digest" => Box::new(SafePop { data_type: DataType::Digest }),
 
         "tasm_list_safeimplu32_push___bool" => Box::new(SafePush { data_type: DataType::Bool }),
         "tasm_list_safeimplu32_push___u32" => Box::new(SafePush { data_type: DataType::U32 }),
@@ -311,12 +310,12 @@ pub fn name_to_snippet(fn_name: &str) -> Box<dyn BasicSnippet> {
         "tasm_list_safeimplu32_push___xfe" => Box::new(SafePush { data_type: DataType::Xfe }),
         "tasm_list_safeimplu32_push___digest" => Box::new(SafePush { data_type: DataType::Digest }),
 
-        "tasm_list_safeimplu32_set_element___bool" => Box::new(SafeSet{ data_type: DataType::Bool}),
-        "tasm_list_safeimplu32_set_element___u32" => Box::new(SafeSet{ data_type: DataType::U32}),
-        "tasm_list_safeimplu32_set_element___u64" => Box::new(SafeSet{ data_type: DataType::U64}),
-        "tasm_list_safeimplu32_set_element___bfe" => Box::new(SafeSet{ data_type: DataType::Bfe}),
-        "tasm_list_safeimplu32_set_element___xfe" => Box::new(SafeSet{ data_type: DataType::Xfe}),
-        "tasm_list_safeimplu32_set_element___digest" => Box::new(SafeSet{ data_type: DataType::Digest}),
+        "tasm_list_safeimplu32_set_element___bool" => Box::new(SafeSet { data_type: DataType::Bool }),
+        "tasm_list_safeimplu32_set_element___u32" => Box::new(SafeSet { data_type: DataType::U32 }),
+        "tasm_list_safeimplu32_set_element___u64" => Box::new(SafeSet { data_type: DataType::U64 }),
+        "tasm_list_safeimplu32_set_element___bfe" => Box::new(SafeSet { data_type: DataType::Bfe }),
+        "tasm_list_safeimplu32_set_element___xfe" => Box::new(SafeSet { data_type: DataType::Xfe }),
+        "tasm_list_safeimplu32_set_element___digest" => Box::new(SafeSet { data_type: DataType::Digest }),
 
         "tasm_list_safeimplu32_new___bool" => Box::new(SafeNew { data_type: DataType::Bool }),
         "tasm_list_safeimplu32_new___u32" => Box::new(SafeNew { data_type: DataType::U32 }),
@@ -325,12 +324,12 @@ pub fn name_to_snippet(fn_name: &str) -> Box<dyn BasicSnippet> {
         "tasm_list_safeimplu32_new___xfe" => Box::new(SafeNew { data_type: DataType::Xfe }),
         "tasm_list_safeimplu32_new___digest" => Box::new(SafeNew { data_type: DataType::Digest }),
 
-        "tasm_list_safeimplu32_length___bool" => Box::new(SafeLength{ data_type: DataType::Bool }),
-        "tasm_list_safeimplu32_length___u32" => Box::new(SafeLength{ data_type: DataType::U32 }),
-        "tasm_list_safeimplu32_length___u64" => Box::new(SafeLength{ data_type: DataType::U64 }),
-        "tasm_list_safeimplu32_length___bfe" => Box::new(SafeLength{ data_type: DataType::Bfe }),
-        "tasm_list_safeimplu32_length___xfe" => Box::new(SafeLength{ data_type: DataType::Xfe }),
-        "tasm_list_safeimplu32_length___digest" => Box::new(SafeLength{ data_type: DataType::Digest }),
+        "tasm_list_safeimplu32_length___bool" => Box::new(SafeLength { data_type: DataType::Bool }),
+        "tasm_list_safeimplu32_length___u32" => Box::new(SafeLength { data_type: DataType::U32 }),
+        "tasm_list_safeimplu32_length___u64" => Box::new(SafeLength { data_type: DataType::U64 }),
+        "tasm_list_safeimplu32_length___bfe" => Box::new(SafeLength { data_type: DataType::Bfe }),
+        "tasm_list_safeimplu32_length___xfe" => Box::new(SafeLength { data_type: DataType::Xfe }),
+        "tasm_list_safeimplu32_length___digest" => Box::new(SafeLength { data_type: DataType::Digest }),
 
         "tasm_list_safeimplu32_set_length___bool" => Box::new(SafeSetLength { data_type: DataType::Bool }),
         "tasm_list_safeimplu32_set_length___u32" => Box::new(SafeSetLength { data_type: DataType::U32 }),
@@ -341,22 +340,22 @@ pub fn name_to_snippet(fn_name: &str) -> Box<dyn BasicSnippet> {
 
         "tasm_list_safeimplu32_multiset_equality" => Box::new(crate::list::multiset_equality::MultisetEquality(ListType::Safe)),
 
-        "tasm_list_safeimplu32_range" => Box::new(Range{list_type: ListType::Safe}),
+        "tasm_list_safeimplu32_range" => Box::new(Range { list_type: ListType::Safe }),
 
         // unsafe lists
-        "tasm_list_unsafeimplu32_get_element___bool" => Box::new(UnsafeGet{data_type: DataType::Bool}),
-        "tasm_list_unsafeimplu32_get_element___u32" => Box::new(UnsafeGet{data_type: DataType::U32}),
-        "tasm_list_unsafeimplu32_get_element___u64" => Box::new(UnsafeGet{data_type: DataType::U64}),
-        "tasm_list_unsafeimplu32_get_element___bfe" => Box::new(UnsafeGet{data_type: DataType::Bfe }),
-        "tasm_list_unsafeimplu32_get_element___xfe" => Box::new(UnsafeGet{data_type: DataType::Xfe }),
-        "tasm_list_unsafeimplu32_get_element___digest" => Box::new(UnsafeGet{data_type: DataType::Digest}),
+        "tasm_list_unsafeimplu32_get_element___bool" => Box::new(UnsafeGet { data_type: DataType::Bool }),
+        "tasm_list_unsafeimplu32_get_element___u32" => Box::new(UnsafeGet { data_type: DataType::U32 }),
+        "tasm_list_unsafeimplu32_get_element___u64" => Box::new(UnsafeGet { data_type: DataType::U64 }),
+        "tasm_list_unsafeimplu32_get_element___bfe" => Box::new(UnsafeGet { data_type: DataType::Bfe }),
+        "tasm_list_unsafeimplu32_get_element___xfe" => Box::new(UnsafeGet { data_type: DataType::Xfe }),
+        "tasm_list_unsafeimplu32_get_element___digest" => Box::new(UnsafeGet { data_type: DataType::Digest }),
 
-        "tasm_list_unsafeimplu32_pop___bool" => Box::new(UnsafePop{ data_type: DataType::Bool }),
-        "tasm_list_unsafeimplu32_pop___u32" => Box::new(UnsafePop{ data_type: DataType::U32 }),
-        "tasm_list_unsafeimplu32_pop___u64" => Box::new(UnsafePop{ data_type: DataType::U64 }),
-        "tasm_list_unsafeimplu32_pop___bfe" => Box::new(UnsafePop{ data_type: DataType::Bfe }),
-        "tasm_list_unsafeimplu32_pop___xfe" => Box::new(UnsafePop{ data_type: DataType::Xfe }),
-        "tasm_list_unsafeimplu32_pop___digest" => Box::new(UnsafePop{ data_type: DataType::Digest }),
+        "tasm_list_unsafeimplu32_pop___bool" => Box::new(UnsafePop { data_type: DataType::Bool }),
+        "tasm_list_unsafeimplu32_pop___u32" => Box::new(UnsafePop { data_type: DataType::U32 }),
+        "tasm_list_unsafeimplu32_pop___u64" => Box::new(UnsafePop { data_type: DataType::U64 }),
+        "tasm_list_unsafeimplu32_pop___bfe" => Box::new(UnsafePop { data_type: DataType::Bfe }),
+        "tasm_list_unsafeimplu32_pop___xfe" => Box::new(UnsafePop { data_type: DataType::Xfe }),
+        "tasm_list_unsafeimplu32_pop___digest" => Box::new(UnsafePop { data_type: DataType::Digest }),
 
         "tasm_list_unsafeimplu32_push___bool" => Box::new(UnsafePush { data_type: DataType::Bool }),
         "tasm_list_unsafeimplu32_push___u32" => Box::new(UnsafePush { data_type: DataType::U32 }),
@@ -391,55 +390,55 @@ pub fn name_to_snippet(fn_name: &str) -> Box<dyn BasicSnippet> {
         "tasm_list_unsafeimplu32_new___xfe" => Box::new(UnsafeNew { data_type: DataType::Xfe }),
         "tasm_list_unsafeimplu32_new___digest" => Box::new(UnsafeNew { data_type: DataType::Digest }),
 
-        "tasm_list_unsafeimplu32_length___bool" => Box::new(UnsafeLength{ data_type: DataType::Bool }),
-        "tasm_list_unsafeimplu32_length___u32" => Box::new(UnsafeLength{ data_type: DataType::U32 }),
-        "tasm_list_unsafeimplu32_length___u64" => Box::new(UnsafeLength{ data_type: DataType::U64 }),
-        "tasm_list_unsafeimplu32_length___bfe" => Box::new(UnsafeLength{ data_type: DataType::Bfe }),
-        "tasm_list_unsafeimplu32_length___xfe" => Box::new(UnsafeLength{ data_type: DataType::Xfe }),
-        "tasm_list_unsafeimplu32_length___digest" => Box::new(UnsafeLength{ data_type: DataType::Digest }),
+        "tasm_list_unsafeimplu32_length___bool" => Box::new(UnsafeLength { data_type: DataType::Bool }),
+        "tasm_list_unsafeimplu32_length___u32" => Box::new(UnsafeLength { data_type: DataType::U32 }),
+        "tasm_list_unsafeimplu32_length___u64" => Box::new(UnsafeLength { data_type: DataType::U64 }),
+        "tasm_list_unsafeimplu32_length___bfe" => Box::new(UnsafeLength { data_type: DataType::Bfe }),
+        "tasm_list_unsafeimplu32_length___xfe" => Box::new(UnsafeLength { data_type: DataType::Xfe }),
+        "tasm_list_unsafeimplu32_length___digest" => Box::new(UnsafeLength { data_type: DataType::Digest }),
 
         "tasm_list_unsafeimplu32_set_length___bool" => Box::new(UnsafeSetLength {
-data_type: DataType::Bool
-}),
+            data_type: DataType::Bool
+        }),
         "tasm_list_unsafeimplu32_set_length___u32" => Box::new(UnsafeSetLength {
-data_type: DataType::U32
-}),
+            data_type: DataType::U32
+        }),
         "tasm_list_unsafeimplu32_set_length___u64" => Box::new(UnsafeSetLength {
-data_type: DataType::U64
-}),
+            data_type: DataType::U64
+        }),
         "tasm_list_unsafeimplu32_set_length___bfe" => Box::new(UnsafeSetLength {
-data_type: DataType::Bfe
-}),
+            data_type: DataType::Bfe
+        }),
         "tasm_list_unsafeimplu32_set_length___xfe" => Box::new(UnsafeSetLength {
-data_type: DataType::Xfe
-}),
+            data_type: DataType::Xfe
+        }),
         "tasm_list_unsafeimplu32_set_length___digest" => Box::new(UnsafeSetLength {
-data_type: DataType::Digest
-}),
+            data_type: DataType::Digest
+        }),
 
         "tasm_list_unsafeimplu32_multiset_equality" => Box::new(crate::list::multiset_equality::MultisetEquality(ListType::Unsafe)),
-        "tasm_list_unsafeimplu32_range" => Box::new(Range{list_type: ListType::Unsafe}),
+        "tasm_list_unsafeimplu32_range" => Box::new(Range { list_type: ListType::Unsafe }),
 
         // Contiguous lists
         "tasm_list_contiguous_list_get_length" => Box::new(contiguous_list::get_length::GetLength),
-        "tasm_list_contiguous_list_get_pointer_list_unsafeimplu32" => Box::new(contiguous_list::get_pointer_list::GetPointerList{output_list_type:ListType::Unsafe}),
-        "tasm_list_contiguous_list_get_pointer_list_safeimplu32" => Box::new(contiguous_list::get_pointer_list::GetPointerList{output_list_type:ListType::Safe}),
+        "tasm_list_contiguous_list_get_pointer_list_unsafeimplu32" => Box::new(contiguous_list::get_pointer_list::GetPointerList { output_list_type: ListType::Unsafe }),
+        "tasm_list_contiguous_list_get_pointer_list_safeimplu32" => Box::new(contiguous_list::get_pointer_list::GetPointerList { output_list_type: ListType::Safe }),
 
         // MMR
         "tasm_mmr_calculate_new_peaks_from_append_unsafeimplu32" => Box::new(CalculateNewPeaksFromAppend { list_type: ListType::Unsafe }),
         "tasm_mmr_calculate_new_peaks_from_append_safeimplu32" => Box::new(CalculateNewPeaksFromAppend { list_type: ListType::Safe }),
         "tasm_mmr_calculate_new_peaks_from_leaf_mutation_unsafeimplu32" => {
-            Box::new(MmrCalculateNewPeaksFromLeafMutationMtIndices{ list_type: ListType::Unsafe} )
+            Box::new(MmrCalculateNewPeaksFromLeafMutationMtIndices { list_type: ListType::Unsafe })
         }
         "tasm_mmr_calculate_new_peaks_from_leaf_mutation_safeimplu32" => {
-            Box::new(MmrCalculateNewPeaksFromLeafMutationMtIndices{ list_type: ListType::Safe} )
+            Box::new(MmrCalculateNewPeaksFromLeafMutationMtIndices { list_type: ListType::Safe })
         }
         "tasm_mmr_leaf_index_to_mt_index_and_peak_index" => Box::new(MmrLeafIndexToMtIndexAndPeakIndex),
         "tasm_mmr_verify_from_secret_in_unsafeimplu32" => Box::new(MmrVerifyLeafMembershipFromSecretIn { list_type: ListType::Unsafe }),
         "tasm_mmr_verify_from_secret_in_safeimplu32" => Box::new(MmrVerifyLeafMembershipFromSecretIn { list_type: ListType::Safe }),
         "tasm_mmr_bag_peaks" => Box::new(BagPeaks),
-        "tasm_mmr_verify_from_memory_unsafeimplu32" => Box::new(MmrVerifyFromMemory { list_type: ListType::Unsafe} ),
-        "tasm_mmr_verify_from_memory_safeimplu32" => Box::new(MmrVerifyFromMemory { list_type: ListType::Safe} ),
+        "tasm_mmr_verify_from_memory_unsafeimplu32" => Box::new(MmrVerifyFromMemory { list_type: ListType::Unsafe }),
+        "tasm_mmr_verify_from_memory_safeimplu32" => Box::new(MmrVerifyFromMemory { list_type: ListType::Safe }),
 
         // other
         "tasm_other_bfe_add" => Box::new(BfeAdd),
@@ -447,37 +446,37 @@ data_type: DataType::Digest
         // recufy
         "tasm_recufier_mt_ap_verify" => Box::new(MerkleVerify),
         "tasm_recufier_proof_stream_dequeue_next_as_merkleroot" => {
-            Box::new(DequeueNextAs{proof_item: ProofItemVariant::MerkleRoot})
+            Box::new(DequeueNextAs { proof_item: ProofItemVariant::MerkleRoot })
         }
         "tasm_recufier_proof_stream_dequeue_next_as_outofdomainbaserow" => {
-            Box::new(DequeueNextAs{proof_item: ProofItemVariant::OutOfDomainBaseRow})
+            Box::new(DequeueNextAs { proof_item: ProofItemVariant::OutOfDomainBaseRow })
         }
         "tasm_recufier_proof_stream_dequeue_next_as_outofdomainextrow" => {
-            Box::new(DequeueNextAs{proof_item: ProofItemVariant::OutOfDomainExtRow})
+            Box::new(DequeueNextAs { proof_item: ProofItemVariant::OutOfDomainExtRow })
         }
         "tasm_recufier_proof_stream_dequeue_next_as_outofdomainquotientsegments" => {
-            Box::new(DequeueNextAs{proof_item: ProofItemVariant::OutOfDomainQuotientSegments})
+            Box::new(DequeueNextAs { proof_item: ProofItemVariant::OutOfDomainQuotientSegments })
         }
         "tasm_recufier_proof_stream_dequeue_next_as_authenticationstructure" => {
-            Box::new(DequeueNextAs{proof_item: ProofItemVariant::AuthenticationStructure})
+            Box::new(DequeueNextAs { proof_item: ProofItemVariant::AuthenticationStructure })
         }
         "tasm_recufier_proof_stream_dequeue_next_as_masterbasetablerows" => {
-            Box::new(DequeueNextAs{proof_item: ProofItemVariant::MasterBaseTableRows})
+            Box::new(DequeueNextAs { proof_item: ProofItemVariant::MasterBaseTableRows })
         }
         "tasm_recufier_proof_stream_dequeue_next_as_masterexttablerows" => {
-            Box::new(DequeueNextAs{proof_item: ProofItemVariant::MasterExtTableRows})
+            Box::new(DequeueNextAs { proof_item: ProofItemVariant::MasterExtTableRows })
         }
         "tasm_recufier_proof_stream_dequeue_next_as_log2paddedheight" => {
-            Box::new(DequeueNextAs{proof_item: ProofItemVariant::Log2PaddedHeight})
+            Box::new(DequeueNextAs { proof_item: ProofItemVariant::Log2PaddedHeight })
         }
         "tasm_recufier_proof_stream_dequeue_next_as_quotientsegmentselements" => {
-            Box::new(DequeueNextAs{proof_item: ProofItemVariant::QuotientSegmentsElements})
+            Box::new(DequeueNextAs { proof_item: ProofItemVariant::QuotientSegmentsElements })
         }
         "tasm_recufier_proof_stream_dequeue_next_as_fricodeword" => {
-            Box::new(DequeueNextAs{proof_item: ProofItemVariant::FriCodeword})
+            Box::new(DequeueNextAs { proof_item: ProofItemVariant::FriCodeword })
         }
         "tasm_recufier_proof_stream_dequeue_next_as_friresponse" => {
-            Box::new(DequeueNextAs{proof_item: ProofItemVariant::FriResponse})
+            Box::new(DequeueNextAs { proof_item: ProofItemVariant::FriResponse })
         }
         "tasm_recufier_read_and_verify_own_program_digest_from_std_in" => Box::new(ReadAndVerifyOwnProgramDigestFromStdIn),
 
@@ -486,13 +485,14 @@ data_type: DataType::Digest
         "tasm_memory_memcpy" => Box::new(MemCpy),
 
         // FRI
-        "tasm_recufier_fri_verify" => Box::new(FriSnippet { test_instance: None } ),
+        #[cfg(not(test))]
+        "tasm_recufier_fri_verify" => Box::new(crate::recufier::fri_verify::FriSnippet {}),
 
         // structure
 
         // mutator sets
         "tasm_neptune_mutator_set_commit" => Box::new(Commit),
-        "tasm_neptune_mutator_get_swbf_indices_1048576_45" => Box::new(GetSwbfIndices{ window_size: 1048576, num_trials: 45 }),
+        "tasm_neptune_mutator_get_swbf_indices_1048576_45" => Box::new(GetSwbfIndices { window_size: 1048576, num_trials: 45 }),
 
         _ => panic!("Could not find \"{fn_name}\" in the function `exported_snippets`. Did you include it there?"),
     }

--- a/tasm-lib/src/exported_snippets.rs
+++ b/tasm-lib/src/exported_snippets.rs
@@ -78,6 +78,7 @@ use crate::mmr::verify_from_secret_in::MmrVerifyLeafMembershipFromSecretIn;
 use crate::neptune::mutator_set::commit::Commit;
 use crate::neptune::mutator_set::get_swbf_indices::GetSwbfIndices;
 use crate::other_snippets::bfe_add::BfeAdd;
+use crate::recufier::fri_verify::FriSnippet;
 use crate::recufier::merkle_verify::MerkleVerify;
 use crate::recufier::proof_stream::dequeue_next_as::DequeueNextAs;
 use crate::recufier::read_and_verify_own_program_digest_from_std_in::ReadAndVerifyOwnProgramDigestFromStdIn;
@@ -483,6 +484,9 @@ data_type: DataType::Digest
         // memory
         "tasm_memory_dyn_malloc" => Box::new(DynMalloc),
         "tasm_memory_memcpy" => Box::new(MemCpy),
+
+        // FRI
+        "tasm_recufier_fri_verify" => Box::new(FriSnippet { test_instance: None } ),
 
         // structure
 

--- a/tasm-lib/src/list.rs
+++ b/tasm-lib/src/list.rs
@@ -18,7 +18,9 @@ use crate::list::unsafeimplu32::pop::UnsafePop;
 use crate::list::unsafeimplu32::push::UnsafePush;
 use crate::list::unsafeimplu32::set::UnsafeSet;
 use crate::list::unsafeimplu32::set_length::UnsafeSetLength;
-use crate::rust_shadowing_helper_functions::{self, safe_list, unsafe_list};
+use crate::rust_shadowing_helper_functions;
+use crate::rust_shadowing_helper_functions::safe_list;
+use crate::rust_shadowing_helper_functions::unsafe_list;
 use crate::traits::basic_snippet::BasicSnippet;
 
 pub mod contiguous_list;

--- a/tasm-lib/src/recufier.rs
+++ b/tasm-lib/src/recufier.rs
@@ -5,6 +5,7 @@ pub mod get_colinearity_check_x;
 pub mod merkle_verify;
 pub mod proof_stream;
 pub mod read_and_verify_own_program_digest_from_std_in;
+#[cfg(test)]
 mod standalone_fri_verify;
 pub mod verify_authentication_paths_for_leaf_and_index_list;
 pub mod xfe_ntt;

--- a/tasm-lib/src/recufier/fri_verify.rs
+++ b/tasm-lib/src/recufier/fri_verify.rs
@@ -1,21 +1,6 @@
-use anyhow::bail;
-use itertools::Itertools;
-use num_traits::Zero;
-use rand::rngs::StdRng;
-use rand::Rng;
-use rand::SeedableRng;
-use triton_vm::arithmetic_domain::ArithmeticDomain;
-use triton_vm::error::FriValidationError;
-use triton_vm::fri::Fri;
 use triton_vm::prelude::*;
 use triton_vm::proof_item::FriResponse;
 use triton_vm::proof_item::ProofItemVariant;
-use triton_vm::proof_stream::ProofStream;
-use triton_vm::twenty_first::prelude::*;
-use twenty_first::shared_math::ntt::intt;
-use twenty_first::shared_math::ntt::ntt;
-use twenty_first::shared_math::other::log_2_ceil;
-use twenty_first::shared_math::traits::PrimitiveRootOfUnity;
 
 use crate::data_type::DataType;
 use crate::field;
@@ -40,8 +25,6 @@ use crate::recufier::verify_authentication_paths_for_leaf_and_index_list::Verify
 use crate::recufier::xfe_ntt::XfeNtt;
 use crate::structure::tasm_object::TasmObject;
 use crate::traits::basic_snippet::BasicSnippet;
-use crate::Digest;
-use crate::VmHasher;
 
 /// `FriVerify` checks that a Reed-Solomon codeword, provided as an oracle, has a low
 /// degree interpolant. Specifically, the algorithm takes a `ProofStream` object, runs the
@@ -51,7 +34,7 @@ use crate::VmHasher;
 /// probability *soundness error* if the codeword is far from low-degree. If the test is
 /// not successful, the VM crashes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, BFieldCodec, TasmObject)]
-pub struct FriVerify {
+pub(crate) struct FriVerify {
     // expansion factor = 1 / rate
     pub expansion_factor: u32,
     pub num_colinearity_checks: u32,
@@ -64,379 +47,6 @@ pub struct FriVerify {
 pub struct FriSnippet {
     #[cfg(test)]
     pub(crate) test_instance: FriVerify,
-}
-
-impl FriVerify {
-    pub fn new(
-        offset: BFieldElement,
-        domain_length: u32,
-        expansion_factor: u32,
-        num_colinearity_checks: u32,
-    ) -> Self {
-        let domain = ArithmeticDomain::of_length(domain_length as usize).with_offset(offset);
-        Self {
-            expansion_factor,
-            num_colinearity_checks,
-            domain_length,
-            domain_offset: domain.offset,
-            domain_generator: domain.generator,
-        }
-    }
-
-    pub fn call(
-        &self,
-        proof_stream: &mut ProofStream<Tip5>,
-        nondeterminism: &NonDeterminism<BFieldElement>,
-    ) -> Vec<(u32, XFieldElement)> {
-        self.inner_verify(proof_stream, &mut nondeterminism.digests.clone())
-            .unwrap()
-    }
-
-    /// Computes the number of rounds
-    pub fn num_rounds(&self) -> usize {
-        let first_round_code_dimension = self.first_round_max_degree() + 1;
-        let max_num_rounds = log_2_ceil(first_round_code_dimension as u128);
-
-        // Skip rounds for which Merkle tree verification cost exceeds arithmetic cost,
-        // because more than half the codeword's locations are queried.
-        let num_rounds_checking_all_locations = self.num_colinearity_checks.ilog2() as u64;
-        let num_rounds_checking_most_locations = num_rounds_checking_all_locations + 1;
-
-        max_num_rounds.saturating_sub(num_rounds_checking_most_locations) as usize
-    }
-
-    /// Computes the max degree of the codeword interpolant after the last round
-    pub fn last_round_max_degree(&self) -> usize {
-        self.first_round_max_degree() >> self.num_rounds()
-    }
-
-    /// Computes the max degree of the very first codeword interpolant
-    pub fn first_round_max_degree(&self) -> usize {
-        assert!(self.domain_length >= self.expansion_factor);
-        (self.domain_length / self.expansion_factor) as usize - 1
-    }
-
-    /// Compute a new list containing the `XFieldElement`s of the given list, but lifted
-    /// to the type `Digest` via padding with 2 zeros.
-    fn map_convert_xfe_to_digest(xfes: &[XFieldElement]) -> Vec<Digest> {
-        xfes.iter().map(|x| (*x).into()).collect()
-    }
-
-    /// Get the x-coordinate of an A or B point in a colinearity check, given the point's
-    /// index and the round number in which the check takes place. In Triton VM, this
-    /// method is called `get_evaluation_argument`.
-    pub fn get_colinearity_check_x(&self, idx: u32, round: usize) -> XFieldElement {
-        let domain_value = self.domain_offset * self.domain_generator.mod_pow_u32(idx);
-        let round_exponent = 2u32.pow(round as u32);
-        let evaluation_argument = domain_value.mod_pow_u32(round_exponent);
-
-        evaluation_argument.lift()
-    }
-
-    /// Verify the FRI proof embedded in the proof stream. This function expands the list
-    /// `nondeterministic_digests` with the digests of the individual authentication paths
-    /// obtained from reduplicating the authentication structures that live in the proof
-    /// stream.
-    fn inner_verify(
-        &self,
-        proof_stream: &mut ProofStream<Tip5>,
-        nondeterministic_digests: &mut Vec<Digest>,
-    ) -> anyhow::Result<Vec<(u32, XFieldElement)>> {
-        let mut num_nondeterministic_digests_read = 0;
-
-        println!("Inside inner_verify.");
-
-        // calculate number of rounds
-        let num_rounds = self.num_rounds();
-        println!("Number of rounds: {num_rounds}");
-        let last_round_max_degree = self.last_round_max_degree();
-        println!("Max degree in last round: {last_round_max_degree}");
-
-        // Extract all roots and calculate alpha based on Fiat-Shamir challenge
-        let mut roots = Vec::with_capacity(num_rounds);
-        let mut alphas = Vec::with_capacity(num_rounds);
-
-        let first_root = proof_stream
-            .dequeue()
-            .unwrap()
-            .try_into_merkle_root()
-            .unwrap();
-        roots.push(first_root);
-
-        for _round in 0..num_rounds {
-            // get a challenge from the verifier
-            let alpha = proof_stream.sample_scalars(1)[0];
-            alphas.push(alpha);
-
-            // get a commitment from the prover
-            let root = proof_stream
-                .dequeue()
-                .unwrap()
-                .try_into_merkle_root()
-                .unwrap();
-            roots.push(root);
-        }
-        println!("alphas:");
-        for alpha in alphas.iter() {
-            println!("{}", alpha);
-        }
-
-        // Extract last codeword
-        let last_codeword = proof_stream
-            .dequeue()
-            .unwrap()
-            .try_into_fri_codeword()
-            .unwrap();
-        assert_eq!(
-            last_codeword.len(),
-            self.domain_length as usize >> self.num_rounds()
-        );
-
-        // Check if last codeword matches the given root
-        let codeword_digests = Self::map_convert_xfe_to_digest(&last_codeword);
-        let last_codeword_merkle_root =
-            MerkleRoot::call(&codeword_digests, 0, codeword_digests.len());
-
-        let last_root = roots.last().unwrap();
-        if *last_root != last_codeword_merkle_root {
-            bail!(FriValidationError::BadMerkleRootForLastCodeword);
-        }
-
-        // Verify that last codeword is of sufficiently low degree
-
-        // Compute interpolant to get the degree of the last codeword.
-        // Note that we don't have to scale the polynomial back to the trace
-        // subgroup since we only check its degree and don't use it further.
-        let log_2_of_n = last_codeword.len().ilog2();
-        let mut last_polynomial = last_codeword.clone();
-
-        let last_fri_domain_generator = self
-            .domain_generator
-            .mod_pow_u32(2u32.pow(num_rounds as u32));
-        intt::<XFieldElement>(&mut last_polynomial, last_fri_domain_generator, log_2_of_n);
-        let last_poly_degree = Polynomial::new(last_polynomial).degree();
-
-        if last_poly_degree > last_round_max_degree as isize {
-            println!(
-                "last_poly_degree is {last_poly_degree}, \
-                degree_of_last_round is {last_round_max_degree}",
-            );
-            bail!(FriValidationError::LastRoundPolynomialHasTooHighDegree)
-        }
-
-        // QUERY PHASE
-
-        // query step 0: get "A" indices and verify set membership of corresponding values.
-        let domain_length = self.domain_length as usize;
-        let num_collinearity_check = self.num_colinearity_checks as usize;
-        let mut a_indices = proof_stream.sample_indices(domain_length, num_collinearity_check);
-
-        let tree_height = self.domain_length.ilog2() as usize;
-        let fri_response = proof_stream
-            .dequeue()
-            .unwrap()
-            .try_into_fri_response()
-            .unwrap();
-        assert_eq!(a_indices.len(), fri_response.revealed_leaves.len());
-        let mut a_values = fri_response.revealed_leaves;
-
-        let leaf_digests = Self::map_convert_xfe_to_digest(&a_values);
-        let indexed_a_leaves = a_indices.iter().copied().zip_eq(leaf_digests).collect_vec();
-
-        // reduplicate authentication structures if necessary
-        if num_nondeterministic_digests_read >= nondeterministic_digests.len() {
-            let inclusion_proof = MerkleTreeInclusionProof::<Tip5> {
-                tree_height,
-                indexed_leaves: indexed_a_leaves.clone(),
-                authentication_structure: fri_response.auth_structure,
-                ..Default::default()
-            };
-
-            // sanity check: the authentication structure was valid, right?
-            assert!(inclusion_proof.clone().verify(roots[0]));
-            let reduplicated_authentication_paths = inclusion_proof.into_authentication_paths()?;
-            nondeterministic_digests
-                .extend(reduplicated_authentication_paths.into_iter().flatten());
-        }
-
-        // verify authentication paths for A leafs
-        for indexed_leaf in indexed_a_leaves {
-            let authentication_path = &nondeterministic_digests[num_nondeterministic_digests_read
-                ..(num_nondeterministic_digests_read + tree_height)];
-            num_nondeterministic_digests_read += tree_height;
-            let inclusion_proof = MerkleTreeInclusionProof::<Tip5> {
-                tree_height,
-                indexed_leaves: vec![indexed_leaf],
-                authentication_structure: authentication_path.to_vec(),
-                ..Default::default()
-            };
-            assert!(inclusion_proof.verify(roots[0]));
-        }
-
-        // save indices and revealed leafs of first round's codeword for returning
-        let revealed_indices_and_elements_first_half = a_indices
-            .iter()
-            .map(|&idx| idx as u32)
-            .zip_eq(a_values.iter().copied())
-            .collect_vec();
-        // these indices and values will be computed in the first iteration of the main loop below
-        let mut revealed_indices_and_elements_second_half = vec![];
-
-        // set up "B" for offsetting inside loop.  Note that "B" and "A" indices can be calculated
-        // from each other.
-        let mut b_indices = a_indices.clone();
-        let mut current_domain_len = self.domain_length as usize;
-        let mut current_tree_height = tree_height;
-
-        // query step 1:  loop over FRI rounds, verify "B"s, compute values for "C"s
-        for r in 0..num_rounds {
-            // get "B" indices and verify set membership of corresponding values
-            b_indices = b_indices
-                .iter()
-                .map(|x| (x + current_domain_len / 2) % current_domain_len)
-                .collect();
-            let fri_response = proof_stream
-                .dequeue()
-                .unwrap()
-                .try_into_fri_response()
-                .unwrap();
-            let b_values = fri_response.revealed_leaves;
-
-            let leaf_digests = Self::map_convert_xfe_to_digest(&b_values);
-            let indexed_b_leaves = b_indices.iter().copied().zip_eq(leaf_digests).collect_vec();
-
-            // reduplicate authentication structures if necessary
-            if num_nondeterministic_digests_read >= nondeterministic_digests.len() {
-                let inclusion_proof = MerkleTreeInclusionProof::<Tip5> {
-                    tree_height: current_tree_height,
-                    indexed_leaves: indexed_b_leaves.clone(),
-                    authentication_structure: fri_response.auth_structure,
-                    ..Default::default()
-                };
-
-                // sanity check: the auth structure was valid, right?
-                assert!(inclusion_proof.clone().verify(roots[r]));
-                let reduplicated_authentication_paths =
-                    inclusion_proof.into_authentication_paths()?;
-                nondeterministic_digests
-                    .extend(reduplicated_authentication_paths.into_iter().flatten());
-            }
-
-            // verify authentication paths for B leafs
-            for indexed_leaf in indexed_b_leaves {
-                let authentication_path = &nondeterministic_digests
-                    [num_nondeterministic_digests_read
-                        ..(num_nondeterministic_digests_read + current_tree_height)];
-                num_nondeterministic_digests_read += current_tree_height;
-                let inclusion_proof = MerkleTreeInclusionProof::<Tip5> {
-                    tree_height: current_tree_height,
-                    indexed_leaves: vec![indexed_leaf],
-                    authentication_structure: authentication_path.to_vec(),
-                    ..Default::default()
-                };
-                if !inclusion_proof.verify(roots[r]) {
-                    bail!(FriValidationError::BadMerkleAuthenticationPath);
-                }
-            }
-
-            debug_assert_eq!(self.num_colinearity_checks, a_indices.len() as u32);
-            debug_assert_eq!(self.num_colinearity_checks, b_indices.len() as u32);
-            debug_assert_eq!(self.num_colinearity_checks, a_values.len() as u32);
-            debug_assert_eq!(self.num_colinearity_checks, b_values.len() as u32);
-
-            if r == 0 {
-                // save other half of indices and revealed leafs of first round for returning
-                revealed_indices_and_elements_second_half = b_indices
-                    .iter()
-                    .map(|&idx| idx as u32)
-                    .zip_eq(b_values.iter().copied())
-                    .collect_vec();
-            }
-
-            // compute "C" indices and values for next round from "A" and "B" of current round
-            current_domain_len /= 2;
-            current_tree_height -= 1;
-            let c_indices = a_indices.iter().map(|x| x % current_domain_len).collect();
-            let c_values = (0..self.num_colinearity_checks as usize)
-                .map(|i| {
-                    let a_x = self.get_colinearity_check_x(a_indices[i] as u32, r);
-                    let b_x = self.get_colinearity_check_x(b_indices[i] as u32, r);
-                    Polynomial::<XFieldElement>::get_colinear_y(
-                        (a_x, a_values[i]),
-                        (b_x, b_values[i]),
-                        alphas[r],
-                    )
-                })
-                .collect();
-
-            // next rounds "A"s correspond to current rounds "C"s
-            a_indices = c_indices;
-            a_values = c_values;
-        }
-
-        // Finally compare "C" values (which are named "A" values in this enclosing scope) with
-        // last codeword from the proofstream.
-        a_indices = a_indices.iter().map(|x| x % current_domain_len).collect();
-        if !(0..self.num_colinearity_checks as usize)
-            .all(|i| last_codeword[a_indices[i]] == a_values[i])
-        {
-            bail!(FriValidationError::LastCodewordMismatch);
-        }
-
-        // compile return object and store to memory
-        let revealed_indices_and_elements = revealed_indices_and_elements_first_half
-            .into_iter()
-            .chain(revealed_indices_and_elements_second_half)
-            .collect_vec();
-
-        Ok(revealed_indices_and_elements)
-    }
-
-    /// Generate a proof, embedded in a proof stream.
-    pub fn pseudorandom_fri_proof_stream(&self, seed: [u8; 32]) -> ProofStream<Tip5> {
-        let max_degree = self.first_round_max_degree();
-        let mut rng: StdRng = SeedableRng::from_seed(seed);
-        let polynomial_coefficients = (0..=max_degree).map(|_| rng.gen()).collect_vec();
-
-        let mut codeword = polynomial_coefficients;
-        codeword.resize(self.domain_length as usize, XFieldElement::zero());
-        let primitive_root =
-            BFieldElement::primitive_root_of_unity(self.domain_length as u64).unwrap();
-        let log_2_of_n = self.domain_length.ilog2();
-        ntt::<XFieldElement>(&mut codeword, primitive_root, log_2_of_n);
-
-        let mut proof_stream = ProofStream::<VmHasher>::new();
-        let fri = self.to_fri();
-        fri.prove(&codeword, &mut proof_stream).unwrap();
-
-        ProofStream {
-            items: proof_stream.items,
-            items_index: 0,
-            sponge_state: Tip5::init(),
-        }
-    }
-
-    pub fn extract_digests_required_for_proving(
-        &self,
-        proof_stream: &ProofStream<Tip5>,
-    ) -> Vec<Digest> {
-        let mut digests = vec![];
-        self.inner_verify(&mut proof_stream.clone(), &mut digests)
-            .unwrap();
-        digests
-    }
-
-    pub fn to_fri(&self) -> Fri<VmHasher> {
-        let fri_domain = ArithmeticDomain::of_length(self.domain_length as usize)
-            .with_offset(self.domain_offset);
-        let maybe_fri = Fri::new(
-            fri_domain,
-            self.expansion_factor as usize,
-            self.num_colinearity_checks as usize,
-        );
-
-        maybe_fri.unwrap()
-    }
 }
 
 impl BasicSnippet for FriSnippet {
@@ -1134,13 +744,29 @@ mod test {
     use std::collections::HashSet;
     use std::panic::catch_unwind;
 
+    use anyhow::bail;
+    use itertools::Itertools;
     use num_traits::One;
+    use num_traits::Zero;
     use proptest::collection::vec;
     use proptest::prelude::*;
     use proptest_arbitrary_interop::arb;
+    use rand::rngs::StdRng;
+    use rand::Rng;
+    use rand::SeedableRng;
     use rayon::prelude::*;
     use test_strategy::proptest;
+    use triton_vm::arithmetic_domain::ArithmeticDomain;
+    use triton_vm::error::FriValidationError;
+    use triton_vm::fri::Fri;
     use triton_vm::proof_item::ProofItem;
+    use triton_vm::proof_stream::ProofStream;
+    use triton_vm::twenty_first::prelude::*;
+    use twenty_first::prelude::tip5::Tip5State;
+    use twenty_first::shared_math::ntt::intt;
+    use twenty_first::shared_math::ntt::ntt;
+    use twenty_first::shared_math::other::log_2_ceil;
+    use twenty_first::shared_math::traits::PrimitiveRootOfUnity;
 
     use crate::empty_stack;
     use crate::memory::dyn_malloc::FIRST_DYNAMICALLY_ALLOCATED_ADDRESS;
@@ -1151,9 +777,383 @@ mod test {
     use crate::traits::procedure::Procedure;
     use crate::traits::procedure::ProcedureInitialState;
     use crate::traits::procedure::ShadowedProcedure;
-    use crate::VmHasherState;
 
     use super::*;
+
+    impl FriVerify {
+        pub fn new(
+            offset: BFieldElement,
+            domain_length: u32,
+            expansion_factor: u32,
+            num_colinearity_checks: u32,
+        ) -> Self {
+            let domain = ArithmeticDomain::of_length(domain_length as usize).with_offset(offset);
+            Self {
+                expansion_factor,
+                num_colinearity_checks,
+                domain_length,
+                domain_offset: domain.offset,
+                domain_generator: domain.generator,
+            }
+        }
+
+        pub fn call(
+            &self,
+            proof_stream: &mut ProofStream<Tip5>,
+            nondeterminism: &NonDeterminism<BFieldElement>,
+        ) -> Vec<(u32, XFieldElement)> {
+            self.inner_verify(proof_stream, &mut nondeterminism.digests.clone())
+                .unwrap()
+        }
+
+        /// Computes the number of rounds
+        pub fn num_rounds(&self) -> usize {
+            let first_round_code_dimension = self.first_round_max_degree() + 1;
+            let max_num_rounds = log_2_ceil(first_round_code_dimension as u128);
+
+            // Skip rounds for which Merkle tree verification cost exceeds arithmetic cost,
+            // because more than half the codeword's locations are queried.
+            let num_rounds_checking_all_locations = self.num_colinearity_checks.ilog2() as u64;
+            let num_rounds_checking_most_locations = num_rounds_checking_all_locations + 1;
+
+            max_num_rounds.saturating_sub(num_rounds_checking_most_locations) as usize
+        }
+
+        /// Computes the max degree of the codeword interpolant after the last round
+        pub fn last_round_max_degree(&self) -> usize {
+            self.first_round_max_degree() >> self.num_rounds()
+        }
+
+        /// Computes the max degree of the very first codeword interpolant
+        pub fn first_round_max_degree(&self) -> usize {
+            assert!(self.domain_length >= self.expansion_factor);
+            (self.domain_length / self.expansion_factor) as usize - 1
+        }
+
+        /// Compute a new list containing the `XFieldElement`s of the given list, but lifted
+        /// to the type `Digest` via padding with 2 zeros.
+        fn map_convert_xfe_to_digest(xfes: &[XFieldElement]) -> Vec<Digest> {
+            xfes.iter().map(|x| (*x).into()).collect()
+        }
+
+        /// Get the x-coordinate of an A or B point in a colinearity check, given the point's
+        /// index and the round number in which the check takes place. In Triton VM, this
+        /// method is called `get_evaluation_argument`.
+        pub fn get_colinearity_check_x(&self, idx: u32, round: usize) -> XFieldElement {
+            let domain_value = self.domain_offset * self.domain_generator.mod_pow_u32(idx);
+            let round_exponent = 2u32.pow(round as u32);
+            let evaluation_argument = domain_value.mod_pow_u32(round_exponent);
+
+            evaluation_argument.lift()
+        }
+
+        /// Verify the FRI proof embedded in the proof stream. This function expands the list
+        /// `nondeterministic_digests` with the digests of the individual authentication paths
+        /// obtained from reduplicating the authentication structures that live in the proof
+        /// stream.
+        fn inner_verify(
+            &self,
+            proof_stream: &mut ProofStream<Tip5>,
+            nondeterministic_digests: &mut Vec<Digest>,
+        ) -> anyhow::Result<Vec<(u32, XFieldElement)>> {
+            let mut num_nondeterministic_digests_read = 0;
+
+            println!("Inside inner_verify.");
+
+            // calculate number of rounds
+            let num_rounds = self.num_rounds();
+            println!("Number of rounds: {num_rounds}");
+            let last_round_max_degree = self.last_round_max_degree();
+            println!("Max degree in last round: {last_round_max_degree}");
+
+            // Extract all roots and calculate alpha based on Fiat-Shamir challenge
+            let mut roots = Vec::with_capacity(num_rounds);
+            let mut alphas = Vec::with_capacity(num_rounds);
+
+            let first_root = proof_stream
+                .dequeue()
+                .unwrap()
+                .try_into_merkle_root()
+                .unwrap();
+            roots.push(first_root);
+
+            for _round in 0..num_rounds {
+                // get a challenge from the verifier
+                let alpha = proof_stream.sample_scalars(1)[0];
+                alphas.push(alpha);
+
+                // get a commitment from the prover
+                let root = proof_stream
+                    .dequeue()
+                    .unwrap()
+                    .try_into_merkle_root()
+                    .unwrap();
+                roots.push(root);
+            }
+            println!("alphas:");
+            for alpha in alphas.iter() {
+                println!("{}", alpha);
+            }
+
+            // Extract last codeword
+            let last_codeword = proof_stream
+                .dequeue()
+                .unwrap()
+                .try_into_fri_codeword()
+                .unwrap();
+            assert_eq!(
+                last_codeword.len(),
+                self.domain_length as usize >> self.num_rounds()
+            );
+
+            // Check if last codeword matches the given root
+            let codeword_digests = Self::map_convert_xfe_to_digest(&last_codeword);
+            let last_codeword_merkle_root =
+                MerkleRoot::call(&codeword_digests, 0, codeword_digests.len());
+
+            let last_root = roots.last().unwrap();
+            if *last_root != last_codeword_merkle_root {
+                bail!(FriValidationError::BadMerkleRootForLastCodeword);
+            }
+
+            // Verify that last codeword is of sufficiently low degree
+
+            // Compute interpolant to get the degree of the last codeword.
+            // Note that we don't have to scale the polynomial back to the trace
+            // subgroup since we only check its degree and don't use it further.
+            let log_2_of_n = last_codeword.len().ilog2();
+            let mut last_polynomial = last_codeword.clone();
+
+            let last_fri_domain_generator = self
+                .domain_generator
+                .mod_pow_u32(2u32.pow(num_rounds as u32));
+            intt::<XFieldElement>(&mut last_polynomial, last_fri_domain_generator, log_2_of_n);
+            let last_poly_degree = Polynomial::new(last_polynomial).degree();
+
+            if last_poly_degree > last_round_max_degree as isize {
+                println!(
+                    "last_poly_degree is {last_poly_degree}, \
+                degree_of_last_round is {last_round_max_degree}",
+                );
+                bail!(FriValidationError::LastRoundPolynomialHasTooHighDegree)
+            }
+
+            // QUERY PHASE
+
+            // query step 0: get "A" indices and verify set membership of corresponding values.
+            let domain_length = self.domain_length as usize;
+            let num_collinearity_check = self.num_colinearity_checks as usize;
+            let mut a_indices = proof_stream.sample_indices(domain_length, num_collinearity_check);
+
+            let tree_height = self.domain_length.ilog2() as usize;
+            let fri_response = proof_stream
+                .dequeue()
+                .unwrap()
+                .try_into_fri_response()
+                .unwrap();
+            assert_eq!(a_indices.len(), fri_response.revealed_leaves.len());
+            let mut a_values = fri_response.revealed_leaves;
+
+            let leaf_digests = Self::map_convert_xfe_to_digest(&a_values);
+            let indexed_a_leaves = a_indices.iter().copied().zip_eq(leaf_digests).collect_vec();
+
+            // reduplicate authentication structures if necessary
+            if num_nondeterministic_digests_read >= nondeterministic_digests.len() {
+                let inclusion_proof = MerkleTreeInclusionProof::<Tip5> {
+                    tree_height,
+                    indexed_leaves: indexed_a_leaves.clone(),
+                    authentication_structure: fri_response.auth_structure,
+                    ..Default::default()
+                };
+
+                // sanity check: the authentication structure was valid, right?
+                assert!(inclusion_proof.clone().verify(roots[0]));
+                let reduplicated_authentication_paths =
+                    inclusion_proof.into_authentication_paths()?;
+                nondeterministic_digests
+                    .extend(reduplicated_authentication_paths.into_iter().flatten());
+            }
+
+            // verify authentication paths for A leafs
+            for indexed_leaf in indexed_a_leaves {
+                let authentication_path = &nondeterministic_digests
+                    [num_nondeterministic_digests_read
+                        ..(num_nondeterministic_digests_read + tree_height)];
+                num_nondeterministic_digests_read += tree_height;
+                let inclusion_proof = MerkleTreeInclusionProof::<Tip5> {
+                    tree_height,
+                    indexed_leaves: vec![indexed_leaf],
+                    authentication_structure: authentication_path.to_vec(),
+                    ..Default::default()
+                };
+                assert!(inclusion_proof.verify(roots[0]));
+            }
+
+            // save indices and revealed leafs of first round's codeword for returning
+            let revealed_indices_and_elements_first_half = a_indices
+                .iter()
+                .map(|&idx| idx as u32)
+                .zip_eq(a_values.iter().copied())
+                .collect_vec();
+            // these indices and values will be computed in the first iteration of the main loop below
+            let mut revealed_indices_and_elements_second_half = vec![];
+
+            // set up "B" for offsetting inside loop.  Note that "B" and "A" indices can be calculated
+            // from each other.
+            let mut b_indices = a_indices.clone();
+            let mut current_domain_len = self.domain_length as usize;
+            let mut current_tree_height = tree_height;
+
+            // query step 1:  loop over FRI rounds, verify "B"s, compute values for "C"s
+            for r in 0..num_rounds {
+                // get "B" indices and verify set membership of corresponding values
+                b_indices = b_indices
+                    .iter()
+                    .map(|x| (x + current_domain_len / 2) % current_domain_len)
+                    .collect();
+                let fri_response = proof_stream
+                    .dequeue()
+                    .unwrap()
+                    .try_into_fri_response()
+                    .unwrap();
+                let b_values = fri_response.revealed_leaves;
+
+                let leaf_digests = Self::map_convert_xfe_to_digest(&b_values);
+                let indexed_b_leaves = b_indices.iter().copied().zip_eq(leaf_digests).collect_vec();
+
+                // reduplicate authentication structures if necessary
+                if num_nondeterministic_digests_read >= nondeterministic_digests.len() {
+                    let inclusion_proof = MerkleTreeInclusionProof::<Tip5> {
+                        tree_height: current_tree_height,
+                        indexed_leaves: indexed_b_leaves.clone(),
+                        authentication_structure: fri_response.auth_structure,
+                        ..Default::default()
+                    };
+
+                    // sanity check: the auth structure was valid, right?
+                    assert!(inclusion_proof.clone().verify(roots[r]));
+                    let reduplicated_authentication_paths =
+                        inclusion_proof.into_authentication_paths()?;
+                    nondeterministic_digests
+                        .extend(reduplicated_authentication_paths.into_iter().flatten());
+                }
+
+                // verify authentication paths for B leafs
+                for indexed_leaf in indexed_b_leaves {
+                    let authentication_path = &nondeterministic_digests
+                        [num_nondeterministic_digests_read
+                            ..(num_nondeterministic_digests_read + current_tree_height)];
+                    num_nondeterministic_digests_read += current_tree_height;
+                    let inclusion_proof = MerkleTreeInclusionProof::<Tip5> {
+                        tree_height: current_tree_height,
+                        indexed_leaves: vec![indexed_leaf],
+                        authentication_structure: authentication_path.to_vec(),
+                        ..Default::default()
+                    };
+                    if !inclusion_proof.verify(roots[r]) {
+                        bail!(FriValidationError::BadMerkleAuthenticationPath);
+                    }
+                }
+
+                debug_assert_eq!(self.num_colinearity_checks, a_indices.len() as u32);
+                debug_assert_eq!(self.num_colinearity_checks, b_indices.len() as u32);
+                debug_assert_eq!(self.num_colinearity_checks, a_values.len() as u32);
+                debug_assert_eq!(self.num_colinearity_checks, b_values.len() as u32);
+
+                if r == 0 {
+                    // save other half of indices and revealed leafs of first round for returning
+                    revealed_indices_and_elements_second_half = b_indices
+                        .iter()
+                        .map(|&idx| idx as u32)
+                        .zip_eq(b_values.iter().copied())
+                        .collect_vec();
+                }
+
+                // compute "C" indices and values for next round from "A" and "B" of current round
+                current_domain_len /= 2;
+                current_tree_height -= 1;
+                let c_indices = a_indices.iter().map(|x| x % current_domain_len).collect();
+                let c_values = (0..self.num_colinearity_checks as usize)
+                    .map(|i| {
+                        let a_x = self.get_colinearity_check_x(a_indices[i] as u32, r);
+                        let b_x = self.get_colinearity_check_x(b_indices[i] as u32, r);
+                        Polynomial::<XFieldElement>::get_colinear_y(
+                            (a_x, a_values[i]),
+                            (b_x, b_values[i]),
+                            alphas[r],
+                        )
+                    })
+                    .collect();
+
+                // next rounds "A"s correspond to current rounds "C"s
+                a_indices = c_indices;
+                a_values = c_values;
+            }
+
+            // Finally compare "C" values (which are named "A" values in this enclosing scope) with
+            // last codeword from the proofstream.
+            a_indices = a_indices.iter().map(|x| x % current_domain_len).collect();
+            if !(0..self.num_colinearity_checks as usize)
+                .all(|i| last_codeword[a_indices[i]] == a_values[i])
+            {
+                bail!(FriValidationError::LastCodewordMismatch);
+            }
+
+            // compile return object and store to memory
+            let revealed_indices_and_elements = revealed_indices_and_elements_first_half
+                .into_iter()
+                .chain(revealed_indices_and_elements_second_half)
+                .collect_vec();
+
+            Ok(revealed_indices_and_elements)
+        }
+
+        /// Generate a proof, embedded in a proof stream.
+        pub fn pseudorandom_fri_proof_stream(&self, seed: [u8; 32]) -> ProofStream<Tip5> {
+            let max_degree = self.first_round_max_degree();
+            let mut rng: StdRng = SeedableRng::from_seed(seed);
+            let polynomial_coefficients = (0..=max_degree).map(|_| rng.gen()).collect_vec();
+
+            let mut codeword = polynomial_coefficients;
+            codeword.resize(self.domain_length as usize, XFieldElement::zero());
+            let primitive_root =
+                BFieldElement::primitive_root_of_unity(self.domain_length as u64).unwrap();
+            let log_2_of_n = self.domain_length.ilog2();
+            ntt::<XFieldElement>(&mut codeword, primitive_root, log_2_of_n);
+
+            let mut proof_stream = ProofStream::<Tip5>::new();
+            let fri = self.to_fri();
+            fri.prove(&codeword, &mut proof_stream).unwrap();
+
+            ProofStream {
+                items: proof_stream.items,
+                items_index: 0,
+                sponge_state: Tip5::init(),
+            }
+        }
+
+        pub fn extract_digests_required_for_proving(
+            &self,
+            proof_stream: &ProofStream<Tip5>,
+        ) -> Vec<Digest> {
+            let mut digests = vec![];
+            self.inner_verify(&mut proof_stream.clone(), &mut digests)
+                .unwrap();
+            digests
+        }
+
+        pub fn to_fri(self) -> Fri<Tip5> {
+            let fri_domain = ArithmeticDomain::of_length(self.domain_length as usize)
+                .with_offset(self.domain_offset);
+            let maybe_fri = Fri::new(
+                fri_domain,
+                self.expansion_factor as usize,
+                self.num_colinearity_checks as usize,
+            );
+
+            maybe_fri.unwrap()
+        }
+    }
 
     impl FriSnippet {
         /// Test helper – panics if verification fails.
@@ -1173,7 +1173,7 @@ mod test {
                 &stack,
                 &[],
                 nondeterminism,
-                &Some(VmHasher::init()),
+                &Some(Tip5::init()),
                 0,
             );
         }
@@ -1226,7 +1226,7 @@ mod test {
             memory: &mut HashMap<BFieldElement, BFieldElement>,
             nondeterminism: &NonDeterminism<BFieldElement>,
             _public_input: &[BFieldElement],
-            sponge_state: &mut Option<VmHasherState>,
+            sponge_state: &mut Option<Tip5State>,
         ) -> Vec<BFieldElement> {
             let fri_pointer = stack.pop().unwrap();
             let fri_verify = *FriVerify::decode_from_memory(memory, fri_pointer).unwrap();
@@ -1276,7 +1276,7 @@ mod test {
                 stack,
                 nondeterminism,
                 public_input: vec![],
-                sponge_state: Some(VmHasher::init()),
+                sponge_state: Some(Tip5::init()),
             }
         }
     }
@@ -1350,7 +1350,7 @@ mod test {
             }
         }
 
-        fn fri(&self) -> Fri<VmHasher> {
+        fn fri(&self) -> Fri<Tip5> {
             self.fri_verify.to_fri()
         }
 
@@ -1395,7 +1395,7 @@ mod test {
                 stack,
                 nondeterminism,
                 public_input: vec![],
-                sponge_state: Some(VmHasher::init()),
+                sponge_state: Some(Tip5::init()),
             }
         }
     }

--- a/tasm-lib/src/recufier/standalone_fri_verify.rs
+++ b/tasm-lib/src/recufier/standalone_fri_verify.rs
@@ -7,6 +7,7 @@ use crate::memory::encode_to_memory;
 use crate::memory::FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS;
 use crate::traits::compiled_program::CompiledProgram;
 
+use super::fri_verify::FriSnippet;
 use super::fri_verify::FriVerify;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
@@ -66,11 +67,13 @@ impl CompiledProgram for StandaloneFriVerify {
     }
 
     fn code() -> (Vec<LabelledInstruction>, Library) {
-        let fri_verify = StandaloneFriVerify::instance();
         let (stack_excess, _) = Self::singleton().pseudorandom_intermediate_state();
 
         let mut library = Library::new();
-        let fri_verify_entrypoint = library.import(Box::new(fri_verify));
+        let snippet = FriSnippet {
+            test_instance: None,
+        };
+        let fri_verify_entrypoint = library.import(Box::new(snippet));
 
         let mut invocation_code = vec![];
         invocation_code.push(triton_instr!(sponge_init));

--- a/tasm-lib/src/recufier/standalone_fri_verify.rs
+++ b/tasm-lib/src/recufier/standalone_fri_verify.rs
@@ -40,9 +40,7 @@ impl StandaloneFriVerify {
         Self { seed }
     }
 
-    fn pseudorandom_intermediate_state(
-        &self,
-    ) -> (Vec<BFieldElement>, NonDeterminism<BFieldElement>) {
+    fn pseudorandom_intermediate_state(&self) -> IntermediateState {
         let fri_verify = StandaloneFriVerify::instance();
         let proof_stream = fri_verify.pseudorandom_fri_proof_stream(self.seed);
         let digests = fri_verify.extract_digests_required_for_proving(&proof_stream);
@@ -54,8 +52,19 @@ impl StandaloneFriVerify {
             .with_digests(digests)
             .with_ram(memory);
         let stack_excess = vec![proof_stream_pointer, fri_verify_pointer];
-        (stack_excess, nondeterminism)
+
+        IntermediateState {
+            fri_verify,
+            stack_excess,
+            nondeterminism,
+        }
     }
+}
+
+struct IntermediateState {
+    fri_verify: FriVerify,
+    stack_excess: Vec<BFieldElement>,
+    nondeterminism: NonDeterminism<BFieldElement>,
 }
 
 impl CompiledProgram for StandaloneFriVerify {
@@ -67,17 +76,17 @@ impl CompiledProgram for StandaloneFriVerify {
     }
 
     fn code() -> (Vec<LabelledInstruction>, Library) {
-        let (stack_excess, _) = Self::singleton().pseudorandom_intermediate_state();
+        let intermediate_state = Self::singleton().pseudorandom_intermediate_state();
 
         let mut library = Library::new();
         let snippet = FriSnippet {
-            test_instance: None,
+            test_instance: intermediate_state.fri_verify,
         };
         let fri_verify_entrypoint = library.import(Box::new(snippet));
 
         let mut invocation_code = vec![];
         invocation_code.push(triton_instr!(sponge_init));
-        for sti in stack_excess {
+        for sti in intermediate_state.stack_excess {
             invocation_code.push(triton_instr!(push sti.value()));
         }
         #[allow(unused_variables)] // used in macro
@@ -105,14 +114,13 @@ mod bench {
         seed[1] = 0xf7;
 
         let public_input = PublicInput::default();
-        let (_, nondeterminism) =
-            StandaloneFriVerify::singleton().pseudorandom_intermediate_state();
+        let intermediate_state = StandaloneFriVerify::singleton().pseudorandom_intermediate_state();
 
         bench_and_profile_program::<StandaloneFriVerify>(
             "tasm_recufier_standalone_fri_verify".to_string(),
             BenchmarkCase::WorstCase,
             &public_input,
-            &nondeterminism,
+            &intermediate_state.nondeterminism,
         );
     }
 }


### PR DESCRIPTION
To call the FRI snippet outside of an internal testing context, we need to have a snippet object that doesn't require us to set FRI's run-time parameters at compile-time. With this change, setting those parameters at compile-time is optional and only required when invoking tests.

All tests pass.

There might be a cleaner way to achieve this. This was just the 1st thing that I came to mind and that I could get to compile.