### PR TITLE
chore: Upgrade to TVM 0.41.0

### DIFF
--- a/tasm-lib/Cargo.toml
+++ b/tasm-lib/Cargo.toml
@@ -29,7 +29,8 @@ rand = "0.8.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.26", features = ["derive"] }
-triton-vm = "0.40.0"
+# triton-vm = "0.41.0"
+triton-vm = { path = "../../triton-vm/triton-vm/" }
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/tasm-lib/benchmarks/tasmlib_verifier_fri_verify.json
+++ b/tasm-lib/benchmarks/tasmlib_verifier_fri_verify.json
@@ -2,22 +2,22 @@
   {
     "name": "tasmlib_verifier_fri_verify",
     "benchmark_result": {
-      "clock_cycle_count": 372345,
-      "hash_table_height": 14496,
-      "u32_table_height": 39020,
-      "op_stack_table_height": 362749,
-      "ram_table_height": 49515
+      "clock_cycle_count": 126121,
+      "hash_table_height": 14808,
+      "u32_table_height": 12046,
+      "op_stack_table_height": 125203,
+      "ram_table_height": 19393
     },
     "case": "CommonCase"
   },
   {
     "name": "tasmlib_verifier_fri_verify",
     "benchmark_result": {
-      "clock_cycle_count": 372345,
-      "hash_table_height": 14496,
-      "u32_table_height": 38910,
-      "op_stack_table_height": 362749,
-      "ram_table_height": 49515
+      "clock_cycle_count": 126121,
+      "hash_table_height": 14808,
+      "u32_table_height": 11671,
+      "op_stack_table_height": 125203,
+      "ram_table_height": 19393
     },
     "case": "WorstCase"
   }

--- a/tasm-lib/benchmarks/tasmlib_verifier_stark_verify_inner_padded_height_256_fri_exp_4.json
+++ b/tasm-lib/benchmarks/tasmlib_verifier_stark_verify_inner_padded_height_256_fri_exp_4.json
@@ -2,11 +2,11 @@
   {
     "name": "tasmlib_verifier_stark_verify_inner_padded_height_256_fri_exp_4",
     "benchmark_result": {
-      "clock_cycle_count": 1182839,
-      "hash_table_height": 181681,
-      "u32_table_height": 44487,
-      "op_stack_table_height": 1625642,
-      "ram_table_height": 509839
+      "clock_cycle_count": 936615,
+      "hash_table_height": 181807,
+      "u32_table_height": 17295,
+      "op_stack_table_height": 1388096,
+      "ram_table_height": 479717
     },
     "case": "CommonCase"
   }

--- a/tasm-lib/benchmarks/tasmlib_verifier_stark_verify_inner_padded_height_512_fri_exp_4.json
+++ b/tasm-lib/benchmarks/tasmlib_verifier_stark_verify_inner_padded_height_512_fri_exp_4.json
@@ -2,11 +2,11 @@
   {
     "name": "tasmlib_verifier_stark_verify_inner_padded_height_512_fri_exp_4",
     "benchmark_result": {
-      "clock_cycle_count": 1206782,
-      "hash_table_height": 190813,
-      "u32_table_height": 50181,
-      "op_stack_table_height": 1659160,
-      "ram_table_height": 512321
+      "clock_cycle_count": 960558,
+      "hash_table_height": 190939,
+      "u32_table_height": 23650,
+      "op_stack_table_height": 1421614,
+      "ram_table_height": 482199
     },
     "case": "CommonCase"
   }


### PR DESCRIPTION
Fix verifier for this new version. Assuming that the suggested fix proposed in <https://github.com/TritonVM/triton-vm/issues/268>, or something similar, is implemented.

Consider this PR a way to speedup your work.

You probably shouldn't merge this PR since:
1. it points to a local version of Triton VM
2. The indeterminate for barycentric evaluation is sampled at an awkward point for the verifier. Changing this, requires a change to TVM though.