### PR TITLE
feat(map): Allow chaining lists before mapping

### DIFF
--- a/tasm-lib/benchmarks/tasmlib_list_higher_order_u32_map_test_hash_xfield_element.json
+++ b/tasm-lib/benchmarks/tasmlib_list_higher_order_u32_map_test_hash_xfield_element.json
@@ -2,22 +2,22 @@
   {
     "name": "tasmlib_list_higher_order_u32_map_test_hash_xfield_element",
     "benchmark_result": {
-      "clock_cycle_count": 2870,
-      "hash_table_height": 822,
+      "clock_cycle_count": 506,
+      "hash_table_height": 250,
       "u32_table_height": 33,
-      "op_stack_table_height": 3290,
-      "ram_table_height": 437
+      "op_stack_table_height": 584,
+      "ram_table_height": 86
     },
     "case": "CommonCase"
   },
   {
     "name": "tasmlib_list_higher_order_u32_map_test_hash_xfield_element",
     "benchmark_result": {
-      "clock_cycle_count": 3182,
-      "hash_table_height": 900,
+      "clock_cycle_count": 4466,
+      "hash_table_height": 1420,
       "u32_table_height": 33,
-      "op_stack_table_height": 3650,
-      "ram_table_height": 485
+      "op_stack_table_height": 5444,
+      "ram_table_height": 806
     },
     "case": "WorstCase"
   }

--- a/tasm-lib/benchmarks/tasmlib_neptune_mutator_get_swbf_indices_1048576_45.json
+++ b/tasm-lib/benchmarks/tasmlib_neptune_mutator_get_swbf_indices_1048576_45.json
@@ -2,22 +2,22 @@
   {
     "name": "tasmlib_neptune_mutator_get_swbf_indices_1048576_45",
     "benchmark_result": {
-      "clock_cycle_count": 4618,
+      "clock_cycle_count": 4397,
       "hash_table_height": 481,
       "u32_table_height": 4633,
-      "op_stack_table_height": 3464,
-      "ram_table_height": 469
+      "op_stack_table_height": 3188,
+      "ram_table_height": 470
     },
     "case": "CommonCase"
   },
   {
     "name": "tasmlib_neptune_mutator_get_swbf_indices_1048576_45",
     "benchmark_result": {
-      "clock_cycle_count": 4618,
+      "clock_cycle_count": 4397,
       "hash_table_height": 481,
       "u32_table_height": 4507,
-      "op_stack_table_height": 3464,
-      "ram_table_height": 469
+      "op_stack_table_height": 3188,
+      "ram_table_height": 470
     },
     "case": "WorstCase"
   }

--- a/tasm-lib/benchmarks/tasmlib_verifier_fri_verify.json
+++ b/tasm-lib/benchmarks/tasmlib_verifier_fri_verify.json
@@ -2,22 +2,22 @@
   {
     "name": "tasmlib_verifier_fri_verify",
     "benchmark_result": {
-      "clock_cycle_count": 45534,
+      "clock_cycle_count": 44905,
       "hash_table_height": 14646,
       "u32_table_height": 17928,
-      "op_stack_table_height": 43861,
-      "ram_table_height": 17532
+      "op_stack_table_height": 42893,
+      "ram_table_height": 17534
     },
     "case": "CommonCase"
   },
   {
     "name": "tasmlib_verifier_fri_verify",
     "benchmark_result": {
-      "clock_cycle_count": 45534,
+      "clock_cycle_count": 44905,
       "hash_table_height": 14646,
       "u32_table_height": 17324,
-      "op_stack_table_height": 43861,
-      "ram_table_height": 17532
+      "op_stack_table_height": 42893,
+      "ram_table_height": 17534
     },
     "case": "WorstCase"
   }

--- a/tasm-lib/benchmarks/tasmlib_verifier_stark_verify_dynamic_inner_padded_height_256_fri_exp_4.json
+++ b/tasm-lib/benchmarks/tasmlib_verifier_stark_verify_dynamic_inner_padded_height_256_fri_exp_4.json
@@ -2,11 +2,11 @@
   {
     "name": "tasmlib_verifier_stark_verify_dynamic_inner_padded_height_256_fri_exp_4",
     "benchmark_result": {
-      "clock_cycle_count": 195488,
-      "hash_table_height": 142843,
-      "u32_table_height": 25110,
-      "op_stack_table_height": 177960,
-      "ram_table_height": 289180
+      "clock_cycle_count": 194859,
+      "hash_table_height": 142849,
+      "u32_table_height": 25541,
+      "op_stack_table_height": 176992,
+      "ram_table_height": 289182
     },
     "case": "CommonCase"
   }

--- a/tasm-lib/benchmarks/tasmlib_verifier_stark_verify_dynamic_inner_padded_height_512_fri_exp_4.json
+++ b/tasm-lib/benchmarks/tasmlib_verifier_stark_verify_dynamic_inner_padded_height_512_fri_exp_4.json
@@ -2,11 +2,11 @@
   {
     "name": "tasmlib_verifier_stark_verify_dynamic_inner_padded_height_512_fri_exp_4",
     "benchmark_result": {
-      "clock_cycle_count": 203513,
-      "hash_table_height": 150535,
-      "u32_table_height": 34005,
-      "op_stack_table_height": 183116,
-      "ram_table_height": 290358
+      "clock_cycle_count": 202884,
+      "hash_table_height": 150541,
+      "u32_table_height": 34793,
+      "op_stack_table_height": 182148,
+      "ram_table_height": 290360
     },
     "case": "CommonCase"
   }

--- a/tasm-lib/benchmarks/tasmlib_verifier_stark_verify_static_inner_padded_height_256_fri_exp_4.json
+++ b/tasm-lib/benchmarks/tasmlib_verifier_stark_verify_static_inner_padded_height_256_fri_exp_4.json
@@ -2,11 +2,11 @@
   {
     "name": "tasmlib_verifier_stark_verify_static_inner_padded_height_256_fri_exp_4",
     "benchmark_result": {
-      "clock_cycle_count": 183785,
-      "hash_table_height": 128797,
-      "u32_table_height": 25976,
-      "op_stack_table_height": 170154,
-      "ram_table_height": 285281
+      "clock_cycle_count": 183156,
+      "hash_table_height": 128803,
+      "u32_table_height": 25891,
+      "op_stack_table_height": 169186,
+      "ram_table_height": 285283
     },
     "case": "CommonCase"
   }

--- a/tasm-lib/benchmarks/tasmlib_verifier_stark_verify_static_inner_padded_height_512_fri_exp_4.json
+++ b/tasm-lib/benchmarks/tasmlib_verifier_stark_verify_static_inner_padded_height_512_fri_exp_4.json
@@ -2,11 +2,11 @@
   {
     "name": "tasmlib_verifier_stark_verify_static_inner_padded_height_512_fri_exp_4",
     "benchmark_result": {
-      "clock_cycle_count": 191810,
-      "hash_table_height": 136489,
-      "u32_table_height": 33693,
-      "op_stack_table_height": 175310,
-      "ram_table_height": 286459
+      "clock_cycle_count": 191181,
+      "hash_table_height": 136495,
+      "u32_table_height": 34185,
+      "op_stack_table_height": 174342,
+      "ram_table_height": 286461
     },
     "case": "CommonCase"
   }

--- a/tasm-lib/src/neptune/mutator_set/get_swbf_indices.rs
+++ b/tasm-lib/src/neptune/mutator_set/get_swbf_indices.rs
@@ -271,37 +271,37 @@ impl Function for GetSwbfIndices {
 }
 
 /// ```text
-/// BEFORE: _ [x_3, x_2, x_1, x_0] input_list output_list index input_u32
-/// AFTER:  _ [x_3, x_2, x_1, x_0] input_list output_list index output_3 output_2 output_1 output_0
+/// BEFORE: _ [x_3, x_2, x_1, x_0] [bu ff er] input_u32
+/// AFTER:  _ [x_3, x_2, x_1, x_0] [bu ff er] output_3 output_2 output_1 output_0
 /// ```
 pub(crate) fn u32_to_u128_add_another_u128() -> RawCode {
+    let buffer_len = Map::NUM_INTERNAL_REGISTERS;
     let assembly = triton_asm!(
         u32_to_u128_add_another_u128:
-        dup 4   // _ [x_3, x_2, x_1, x_0] input_list output_list index input_u32 x_0
-        add     // _ [x_3, x_2, x_1, x_0] input_list output_list index (input_u32 + x_0)
-        split   // _ [x_3, x_2, x_1, x_0] input_list output_list index carry_to_1 output_0
-        swap 1  // _ [x_3, x_2, x_1, x_0] input_list output_list index output_0 carry_to_1
-        dup 6   // _ [x_3, x_2, x_1, x_0] input_list output_list index output_0 carry_to_1 x_1
+        dup {buffer_len + 1}
+        add     // _ [x_3, x_2, x_1, x_0] [bu ff er] (input_u32 + x_0)
+        split   // _ [x_3, x_2, x_1, x_0] [bu ff er] carry_to_1 output_0
+        pick 1  // _ [x_3, x_2, x_1, x_0] [bu ff er] output_0 carry_to_1
+        dup {buffer_len + 3}
         add
-        split   // _ [x_3, x_2, x_1, x_0] input_list output_list index output_0 carry_to_2 output_1
-        swap 1  // _ [x_3, x_2, x_1, x_0] input_list output_list index output_0 output_1 carry_to_2
-        dup 8
+        split   // _ [x_3, x_2, x_1, x_0] [bu ff er] output_0 carry_to_2 output_1
+        pick 1  // _ [x_3, x_2, x_1, x_0] [bu ff er] output_0 output_1 carry_to_2
+        dup {buffer_len + 5}
         add
-        split   // _ [x_3, x_2, x_1, x_0] input_list output_list index output_0 output_1 carry_to_3 output_2
-        swap 1  // _ [x_3, x_2, x_1, x_0] input_list output_list index output_0 output_1 output_2 carry_to_3
-        dup 10
+        split   // _ [x_3, x_2, x_1, x_0] [bu ff er] output_0 output_1 carry_to_3 output_2
+        pick 1  // _ [x_3, x_2, x_1, x_0] [bu ff er] output_0 output_1 output_2 carry_to_3
+        dup {buffer_len + 7}
         add
-        split   // _ [x_3, x_2, x_1, x_0] input_list output_list index output_0 output_1 output_2 overflow output_3
-        swap 1  // _ [x_3, x_2, x_1, x_0] input_list output_list index output_0 output_1 output_2 output_3 overflow
+        split   // _ [x_3, x_2, x_1, x_0] [bu ff er] output_0 output_1 output_2 overflow output_3
+        pick 1  // _ [x_3, x_2, x_1, x_0] [bu ff er] output_0 output_1 output_2 output_3 overflow
 
         // verify no overflow
         push 0
         eq
-        assert  // _ [x_3, x_2, x_1, x_0] input_list output_list index output_0 output_1 output_2 output_3
-        swap 3
-        swap 1
-        swap 2
-        swap 1  // _ [x_3, x_2, x_1, x_0] input_list output_list index output_3 output_2 output_1 output_0
+        assert  // _ [x_3, x_2, x_1, x_0] [bu ff er] output_0 output_1 output_2 output_3
+        place 3
+        place 2
+        place 1 // _ [x_3, x_2, x_1, x_0] [bu ff er] output_3 output_2 output_1 output_0
         return
     );
     RawCode::new(assembly, DataType::U32, DataType::U128)

--- a/tasm-lib/src/test_helpers.rs
+++ b/tasm-lib/src/test_helpers.rs
@@ -318,13 +318,19 @@ pub fn verify_stack_equivalence(
     stack_b_name: &str,
     stack_b: &[BFieldElement],
 ) {
+    let stack_a_name = format!("{stack_a_name}:");
+    let stack_b_name = format!("{stack_b_name}:");
+    let max_stack_name_len = stack_a_name.len().max(stack_b_name.len());
+
     let stack_a = &stack_a[Digest::LEN..];
     let stack_b = &stack_b[Digest::LEN..];
-    let display = |stack: &[BFieldElement]| stack.iter().map(|&x| x.to_string()).join(",");
+    let display = |stack: &[BFieldElement]| stack.iter().join(",");
     assert_eq!(
         stack_a,
         stack_b,
-        "{stack_a_name} stack must match {stack_b_name} stack\n\n{stack_a_name}: {}\n\n{stack_b_name}: {}",
+        "{stack_a_name} stack must match {stack_b_name} stack\n\n\
+         {stack_a_name:<max_stack_name_len$} {}\n\n\
+         {stack_b_name:<max_stack_name_len$} {}",
         display(stack_a),
         display(stack_b),
     );


### PR DESCRIPTION
Previously, the higher-order assembly function `map` took all elements of an input list, mapped them according to some supplied function, and generated an output list. Equivalently, written in rust, this was:`list.into_iter().map(f).collect_vec()`.

Now, `map` is generalized over the number of input lists, enabling chaining multiple input lists while still producing only one output list. As rust: `list_0.into_iter().chain(list_1).map(f).collect_vec()`.

Between 0 and 15 (both inclusive) input lists are supported.

Note: the ABI for map has changed. Before, an inner function could access runtime parameters on the stack at a distance of 3. Now, this distance has increased to (3 + num_input_lists). For a “traditional” map, this is now 4.