### PR TITLE
Implement `BasicSnippet` for `AddU64`

### DIFF
--- a/tasm-lib/benchmarks/tasm_lib_mmr_verify_mmr_successor.json
+++ b/tasm-lib/benchmarks/tasm_lib_mmr_verify_mmr_successor.json
@@ -2,8 +2,8 @@
   {
     "name": "tasm_lib_mmr_verify_mmr_successor",
     "benchmark_result": {
-      "clock_cycle_count": 23555,
-      "hash_table_height": 3792,
+      "clock_cycle_count": 23427,
+      "hash_table_height": 3786,
       "u32_table_height": 8260,
       "op_stack_table_height": 14528,
       "ram_table_height": 473
@@ -13,8 +13,8 @@
   {
     "name": "tasm_lib_mmr_verify_mmr_successor",
     "benchmark_result": {
-      "clock_cycle_count": 70739,
-      "hash_table_height": 12342,
+      "clock_cycle_count": 70491,
+      "hash_table_height": 12336,
       "u32_table_height": 16787,
       "op_stack_table_height": 41834,
       "ram_table_height": 893

--- a/tasm-lib/benchmarks/tasmlib_arithmetic_u64_add.json
+++ b/tasm-lib/benchmarks/tasmlib_arithmetic_u64_add.json
@@ -2,9 +2,9 @@
   {
     "name": "tasmlib_arithmetic_u64_add",
     "benchmark_result": {
-      "clock_cycle_count": 16,
-      "hash_table_height": 18,
-      "u32_table_height": 34,
+      "clock_cycle_count": 14,
+      "hash_table_height": 12,
+      "u32_table_height": 66,
       "op_stack_table_height": 8,
       "ram_table_height": 0
     },
@@ -13,9 +13,9 @@
   {
     "name": "tasmlib_arithmetic_u64_add",
     "benchmark_result": {
-      "clock_cycle_count": 16,
-      "hash_table_height": 18,
-      "u32_table_height": 38,
+      "clock_cycle_count": 14,
+      "hash_table_height": 12,
+      "u32_table_height": 60,
       "op_stack_table_height": 8,
       "ram_table_height": 0
     },

--- a/tasm-lib/benchmarks/tasmlib_mmr_calculate_new_peaks_from_leaf_mutation.json
+++ b/tasm-lib/benchmarks/tasmlib_mmr_calculate_new_peaks_from_leaf_mutation.json
@@ -2,7 +2,7 @@
   {
     "name": "tasmlib_mmr_calculate_new_peaks_from_leaf_mutation",
     "benchmark_result": {
-      "clock_cycle_count": 2272,
+      "clock_cycle_count": 2270,
       "hash_table_height": 414,
       "u32_table_height": 1069,
       "op_stack_table_height": 1462,
@@ -13,7 +13,7 @@
   {
     "name": "tasmlib_mmr_calculate_new_peaks_from_leaf_mutation",
     "benchmark_result": {
-      "clock_cycle_count": 4332,
+      "clock_cycle_count": 4330,
       "hash_table_height": 600,
       "u32_table_height": 1683,
       "op_stack_table_height": 2840,

--- a/tasm-lib/benchmarks/tasmlib_mmr_leaf_index_to_mt_index_and_peak_index.json
+++ b/tasm-lib/benchmarks/tasmlib_mmr_leaf_index_to_mt_index_and_peak_index.json
@@ -2,8 +2,8 @@
   {
     "name": "tasmlib_mmr_leaf_index_to_mt_index_and_peak_index",
     "benchmark_result": {
-      "clock_cycle_count": 111,
-      "hash_table_height": 120,
+      "clock_cycle_count": 109,
+      "hash_table_height": 114,
       "u32_table_height": 298,
       "op_stack_table_height": 69,
       "ram_table_height": 0
@@ -13,8 +13,8 @@
   {
     "name": "tasmlib_mmr_leaf_index_to_mt_index_and_peak_index",
     "benchmark_result": {
-      "clock_cycle_count": 111,
-      "hash_table_height": 120,
+      "clock_cycle_count": 109,
+      "hash_table_height": 114,
       "u32_table_height": 326,
       "op_stack_table_height": 69,
       "ram_table_height": 0

--- a/tasm-lib/benchmarks/tasmlib_mmr_verify_from_memory.json
+++ b/tasm-lib/benchmarks/tasmlib_mmr_verify_from_memory.json
@@ -2,7 +2,7 @@
   {
     "name": "tasmlib_mmr_verify_from_memory",
     "benchmark_result": {
-      "clock_cycle_count": 1509,
+      "clock_cycle_count": 1507,
       "hash_table_height": 420,
       "u32_table_height": 1399,
       "op_stack_table_height": 1172,
@@ -13,7 +13,7 @@
   {
     "name": "tasmlib_mmr_verify_from_memory",
     "benchmark_result": {
-      "clock_cycle_count": 2856,
+      "clock_cycle_count": 2854,
       "hash_table_height": 606,
       "u32_table_height": 1525,
       "op_stack_table_height": 2240,

--- a/tasm-lib/benchmarks/tasmlib_mmr_verify_from_secret_in_leaf_index_on_stack.json
+++ b/tasm-lib/benchmarks/tasmlib_mmr_verify_from_secret_in_leaf_index_on_stack.json
@@ -2,7 +2,7 @@
   {
     "name": "tasmlib_mmr_verify_from_secret_in_leaf_index_on_stack",
     "benchmark_result": {
-      "clock_cycle_count": 1059,
+      "clock_cycle_count": 1057,
       "hash_table_height": 360,
       "u32_table_height": 788,
       "op_stack_table_height": 570,
@@ -13,7 +13,7 @@
   {
     "name": "tasmlib_mmr_verify_from_secret_in_leaf_index_on_stack",
     "benchmark_result": {
-      "clock_cycle_count": 1899,
+      "clock_cycle_count": 1897,
       "hash_table_height": 540,
       "u32_table_height": 902,
       "op_stack_table_height": 990,

--- a/tasm-lib/benchmarks/tasmlib_mmr_verify_from_secret_in_secret_leaf_index.json
+++ b/tasm-lib/benchmarks/tasmlib_mmr_verify_from_secret_in_secret_leaf_index.json
@@ -2,8 +2,8 @@
   {
     "name": "tasmlib_mmr_verify_from_secret_in_secret_leaf_index",
     "benchmark_result": {
-      "clock_cycle_count": 1071,
-      "hash_table_height": 378,
+      "clock_cycle_count": 1069,
+      "hash_table_height": 372,
       "u32_table_height": 755,
       "op_stack_table_height": 576,
       "ram_table_height": 5
@@ -13,8 +13,8 @@
   {
     "name": "tasmlib_mmr_verify_from_secret_in_secret_leaf_index",
     "benchmark_result": {
-      "clock_cycle_count": 1911,
-      "hash_table_height": 558,
+      "clock_cycle_count": 1909,
+      "hash_table_height": 552,
       "u32_table_height": 967,
       "op_stack_table_height": 996,
       "ram_table_height": 5

--- a/tasm-lib/src/arithmetic/u64/add_u64.rs
+++ b/tasm-lib/src/arithmetic/u64/add_u64.rs
@@ -1,334 +1,144 @@
-use std::collections::HashMap;
-
-use num::Zero;
-use rand::prelude::*;
+use tasm_lib::prelude::BasicSnippet;
 use triton_vm::prelude::*;
-use triton_vm::twenty_first::prelude::U32s;
 
 use crate::data_type::DataType;
-use crate::empty_stack;
 use crate::library::Library;
-use crate::push_encodable;
-use crate::traits::deprecated_snippet::DeprecatedSnippet;
-use crate::InitVmState;
 
 #[derive(Clone, Debug)]
 pub struct AddU64;
 
-impl DeprecatedSnippet for AddU64 {
-    fn entrypoint_name(&self) -> String {
+impl AddU64 {
+    pub const OVERFLOW_ERROR_ID: i128 = 310;
+}
+
+impl BasicSnippet for AddU64 {
+    fn inputs(&self) -> Vec<(DataType, String)> {
+        ["rhs", "lhs"]
+            .map(|side| (DataType::U64, side.to_string()))
+            .to_vec()
+    }
+
+    fn outputs(&self) -> Vec<(DataType, String)> {
+        vec![(DataType::U64, "sum".to_string())]
+    }
+
+    fn entrypoint(&self) -> String {
         "tasmlib_arithmetic_u64_add".to_string()
     }
 
-    fn input_field_names(&self) -> Vec<String> {
-        vec![
-            "rhs_hi".to_string(),
-            "rhs_lo".to_string(),
-            "lhs_hi".to_string(),
-            "lhs_lo".to_string(),
-        ]
-    }
+    fn code(&self, _: &mut Library) -> Vec<LabelledInstruction> {
+        // BEFORE: _ rhs_hi rhs_lo lhs_hi lhs_lo
+        // AFTER:  _ sum_hi sum_lo
+        triton_asm!({self.entrypoint()}:
+            pick 2
+            // _ rhs_hi lhs_hi lhs_lo rhs_lo
 
-    fn input_types(&self) -> Vec<crate::data_type::DataType> {
-        vec![DataType::U64, DataType::U64]
-    }
+            add
+            split
+            // _ rhs_hi lhs_hi carry sum_lo
 
-    fn output_field_names(&self) -> Vec<String> {
-        vec!["(lhs + rhs)_hi".to_string(), "(lhs + rhs)_lo".to_string()]
-    }
+            place 3
+            // _ sum_lo rhs_hi lhs_hi carry
 
-    fn output_types(&self) -> Vec<crate::data_type::DataType> {
-        vec![DataType::U64]
-    }
+            add
+            add
+            // _ sum_lo (lhs_hi+rhs_hi+carry)
 
-    fn stack_diff(&self) -> isize {
-        -2
-    }
+            split
+            // _ sum_lo overflow sum_hi
 
-    /// Four top elements of stack are assumed to be valid u32s. So to have
-    /// a value that's less than 2^32.
-    fn function_code(&self, _library: &mut Library) -> String {
-        let entrypoint = self.entrypoint_name();
+            place 2
+            push 0
+            eq
+            assert error_id {Self::OVERFLOW_ERROR_ID}
+            // _ sum_hi sum_lo
 
-        format!(
-            "
-            // BEFORE: _ rhs_hi rhs_lo lhs_hi lhs_lo
-            // AFTER:  _ sum_hi sum_lo
-            {entrypoint}:
-                swap 1 swap 2
-                // _ rhs_hi lhs_hi lhs_lo rhs_lo
-
-                add
-                split
-                // _ rhs_hi lhs_hi carry sum_lo
-
-                swap 3
-                // _ sum_lo lhs_hi carry rhs_hi
-
-                add
-                add
-                // _ sum_lo (lhs_hi+rhs_hi+carry)
-
-                split
-                // _ sum_lo overflow sum_hi
-
-                swap 1
-                push 0
-                eq
-                assert
-                // _ sum_lo sum_hi
-
-                swap 1
-                // _ sum_hi sum_lo
-
-                return
-            "
+            return
         )
-    }
-
-    fn crash_conditions(&self) -> Vec<String> {
-        vec!["if (lhs + rhs) overflows u64".to_string()]
-    }
-
-    fn gen_input_states(&self) -> Vec<InitVmState> {
-        let mut rng = rand::thread_rng();
-
-        let zero = U32s::<2>::zero();
-        let small_a: U32s<2> = rng.gen::<u32>().into();
-        let small_b: U32s<2> = rng.gen::<u32>().into();
-        let large_a = U32s::<2>::try_from(rng.gen::<u64>()).unwrap();
-        // let large_b = U32s::<2>::try_from(rng.gen::<u64>()).unwrap();
-
-        let mut states = vec![];
-
-        // 0. one zero, one large
-        states.push({
-            let mut stack = empty_stack();
-            push_encodable(&mut stack, &zero);
-            push_encodable(&mut stack, &large_a);
-            InitVmState::with_stack(stack)
-        });
-
-        // 1. two small
-        states.push({
-            let mut stack = empty_stack();
-            push_encodable(&mut stack, &small_a);
-            push_encodable(&mut stack, &small_b);
-            InitVmState::with_stack(stack)
-        });
-
-        states
-    }
-
-    fn common_case_input_state(&self) -> InitVmState {
-        InitVmState::with_stack(
-            [
-                empty_stack(),
-                vec![BFieldElement::zero(), BFieldElement::new(1 << 31)],
-                vec![BFieldElement::zero(), BFieldElement::new(1 << 30)],
-            ]
-            .concat(),
-        )
-    }
-
-    fn worst_case_input_state(&self) -> InitVmState {
-        InitVmState::with_stack(
-            [
-                empty_stack(),
-                vec![BFieldElement::new(1 << 31), BFieldElement::new(1 << 31)],
-                vec![
-                    BFieldElement::new(1 << 30),
-                    BFieldElement::new((1 << 31) + 10),
-                ],
-            ]
-            .concat(),
-        )
-    }
-
-    fn rust_shadowing(
-        &self,
-        stack: &mut Vec<BFieldElement>,
-        _std_in: Vec<BFieldElement>,
-        _secret_in: Vec<BFieldElement>,
-        _memory: &mut HashMap<BFieldElement, BFieldElement>,
-    ) {
-        // top element on stack
-        let a0: u32 = stack.pop().unwrap().try_into().unwrap();
-        let b0: u32 = stack.pop().unwrap().try_into().unwrap();
-        let ab0 = U32s::<2>::new([a0, b0]);
-
-        // second element on stack
-        let a1: u32 = stack.pop().unwrap().try_into().unwrap();
-        let b1: u32 = stack.pop().unwrap().try_into().unwrap();
-        let ab1 = U32s::<2>::new([a1, b1]);
-        let ab0_plus_ab1 = ab0 + ab1;
-        let mut res = ab0_plus_ab1.encode();
-        for _ in 0..res.len() {
-            stack.push(res.pop().unwrap());
-        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use num::BigUint;
-    use num::One;
-    use num::Zero;
+    use itertools::Itertools;
+    use proptest::prop_assume;
     use rand::prelude::*;
+    use test_strategy::proptest;
 
     use super::*;
-    use crate::empty_stack;
-    use crate::test_helpers::test_rust_equivalence_given_input_values_deprecated;
-    use crate::test_helpers::test_rust_equivalence_multiple_deprecated;
+    use crate::pop_encodable;
+    use crate::push_encodable;
+    use crate::snippet_bencher::BenchmarkCase;
+    use crate::test_helpers::test_assertion_failure;
+    use crate::test_helpers::test_rust_equivalence_given_execution_state;
+    use crate::traits::closure::Closure;
+    use crate::traits::closure::ShadowedClosure;
+    use crate::traits::rust_shadow::RustShadow;
+    use crate::InitVmState;
 
-    #[test]
-    fn add_u64_test() {
-        test_rust_equivalence_multiple_deprecated(&AddU64, true);
-    }
+    impl AddU64 {
+        fn prepare_stack(&self, left: u64, right: u64) -> Vec<BFieldElement> {
+            let mut stack = self.init_stack_for_isolated_run();
+            push_encodable(&mut stack, &right);
+            push_encodable(&mut stack, &left);
 
-    #[test]
-    fn u32s_2_add_no_overflow() {
-        // 127 + 129 = 256
-        let mut expected_end_stack = [
-            empty_stack(),
-            vec![BFieldElement::zero(), BFieldElement::new(256)],
-        ]
-        .concat();
-        prop_add(
-            U32s::new([127, 0]),
-            U32s::new([129, 0]),
-            Some(&expected_end_stack),
-        );
-
-        // 127 + 129 + 45 * 2^32 + 1000 * 2^32 = 256 + 1045*2^32
-        expected_end_stack = [
-            empty_stack(),
-            vec![BFieldElement::new(1045), BFieldElement::new(256)],
-        ]
-        .concat();
-        prop_add(
-            U32s::new([127, 45]),
-            U32s::new([129, 1000]),
-            Some(&expected_end_stack),
-        );
-
-        // (2^32 - 1) + 0 + 0 * 2^32 + 2004 * 2^32 = (2^32 - 1) + 2004*2^32
-        expected_end_stack = [
-            empty_stack(),
-            vec![
-                BFieldElement::new(2004),
-                BFieldElement::new(u32::MAX as u64),
-            ],
-        ]
-        .concat();
-        prop_add(
-            U32s::new([u32::MAX, 0]),
-            U32s::new([0, 2004]),
-            Some(&expected_end_stack),
-        );
-
-        // (2^31 - 1) + 2^31 + 14 * 2^32 + 10^9 * 2^32 = (2^32 - 1) + (10^9 + 14) * 2^32
-        expected_end_stack = [
-            empty_stack(),
-            vec![
-                BFieldElement::new(1_000_000_014),
-                BFieldElement::new(u32::MAX as u64),
-            ],
-        ]
-        .concat();
-        prop_add(
-            U32s::new([(1 << 31) - 1, 14]),
-            U32s::new([1 << 31, 1_000_000_000]),
-            Some(&expected_end_stack),
-        );
-    }
-
-    #[test]
-    fn u32s_2_add_with_overflow_in_least_significant_u32() {
-        // 2 ^ 31 + 2 ^ 31 = 0 + 1 * 2 ^32
-        let expected_end_stack = [
-            empty_stack(),
-            vec![BFieldElement::one(), BFieldElement::zero()],
-        ]
-        .concat();
-        prop_add(
-            U32s::new([1 << 31, 0]),
-            U32s::new([1 << 31, 0]),
-            Some(&expected_end_stack),
-        );
-
-        // 2 ^ 32 + 2 ^ 32 - 1 - 2 = (1^32 - 3) + 1 * 2^32
-        let expected_end_stack = [
-            empty_stack(),
-            vec![BFieldElement::one(), BFieldElement::new((1 << 32) - 3)],
-        ]
-        .concat();
-        prop_add(
-            U32s::new([((1u64 << 32) - 1) as u32, 0]),
-            U32s::new([((1u64 << 32) - 2) as u32, 0]),
-            Some(&expected_end_stack),
-        );
-    }
-
-    #[test]
-    fn u32s_2_add_pbt() {
-        let mut rng = rand::thread_rng();
-        for _ in 0..100 {
-            prop_add(
-                U32s::new([rng.next_u32(), rng.next_u32() / 2]),
-                U32s::new([rng.next_u32(), rng.next_u32() / 2]),
-                None,
-            );
+            stack
         }
     }
 
-    #[should_panic]
-    #[test]
-    fn overflow_test() {
-        let lhs: U32s<2> = U32s::from(BigUint::from(1u64 << 63));
-        let rhs: U32s<2> = U32s::from(BigUint::from((1u64 << 63) + 1));
-        let mut init_stack = empty_stack();
-        for elem in rhs.encode().into_iter().rev() {
-            init_stack.push(elem);
-        }
-        for elem in lhs.encode().into_iter().rev() {
-            init_stack.push(elem);
+    impl Closure for AddU64 {
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
+            let sum = pop_encodable::<u64>(stack) + pop_encodable::<u64>(stack);
+            push_encodable(stack, &sum);
         }
 
-        AddU64.link_and_run_tasm_from_state_for_test(&mut InitVmState::with_stack(init_stack));
+        fn pseudorandom_initial_state(
+            &self,
+            seed: [u8; 32],
+            _: Option<BenchmarkCase>,
+        ) -> Vec<BFieldElement> {
+            let mut rng = StdRng::from_seed(seed);
+            let left = rng.gen();
+            let right = rng.gen_range(0..u64::MAX - left);
+
+            self.prepare_stack(left, right)
+        }
+
+        fn corner_case_initial_states(&self) -> Vec<Vec<BFieldElement>> {
+            let boundary_points = [0, 1 << 32, u64::MAX]
+                .into_iter()
+                .flat_map(|p| [p.checked_sub(1), Some(p), p.checked_add(1)])
+                .flatten()
+                .collect_vec();
+
+            boundary_points
+                .iter()
+                .cartesian_product(&boundary_points)
+                .filter(|(&left, &right)| left.checked_add(right).is_some())
+                .map(|(&left, &right)| self.prepare_stack(left, right))
+                .collect()
+        }
     }
 
-    #[should_panic]
     #[test]
-    fn overflow_test_2() {
-        let lhs: U32s<2> = U32s::from(BigUint::from(u64::MAX));
-        let rhs: U32s<2> = U32s::from(BigUint::from(u64::MAX));
-        let mut init_stack = empty_stack();
-        for elem in rhs.encode().into_iter().rev() {
-            init_stack.push(elem);
-        }
-        for elem in lhs.encode().into_iter().rev() {
-            init_stack.push(elem);
-        }
-
-        AddU64.link_and_run_tasm_from_state_for_test(&mut InitVmState::with_stack(init_stack));
+    fn unit_test() {
+        ShadowedClosure::new(AddU64).test();
     }
 
-    fn prop_add(lhs: U32s<2>, rhs: U32s<2>, expected: Option<&[BFieldElement]>) {
-        let mut init_stack = empty_stack();
-        for elem in rhs.encode().into_iter().rev() {
-            init_stack.push(elem);
-        }
-        for elem in lhs.encode().into_iter().rev() {
-            init_stack.push(elem);
-        }
+    #[proptest]
+    fn proptest(left: u64, #[strategy(0..u64::MAX - #left)] right: u64) {
+        let initial_state = InitVmState::with_stack(AddU64.prepare_stack(left, right));
+        test_rust_equivalence_given_execution_state(&ShadowedClosure::new(AddU64), initial_state);
+    }
 
-        test_rust_equivalence_given_input_values_deprecated(
-            &AddU64,
-            &init_stack,
-            &[],
-            HashMap::default(),
-            expected,
+    #[proptest]
+    fn triton_vm_crashes_on_overflowing_add(left: u64, #[strategy(u64::MAX - #left..)] right: u64) {
+        prop_assume!(left.checked_add(right).is_none());
+
+        test_assertion_failure(
+            &ShadowedClosure::new(AddU64),
+            InitVmState::with_stack(AddU64.prepare_stack(left, right)),
+            &[AddU64::OVERFLOW_ERROR_ID],
         );
     }
 }
@@ -336,10 +146,11 @@ mod tests {
 #[cfg(test)]
 mod benches {
     use super::*;
-    use crate::snippet_bencher::bench_and_write;
+    use crate::traits::closure::ShadowedClosure;
+    use crate::traits::rust_shadow::RustShadow;
 
     #[test]
-    fn add_u64_benchmark() {
-        bench_and_write(AddU64);
+    fn bench() {
+        ShadowedClosure::new(AddU64).bench()
     }
 }

--- a/tasm-lib/src/assertion_error_ids.md
+++ b/tasm-lib/src/assertion_error_ids.md
@@ -40,3 +40,4 @@ often.
 |  220..230 | [`TasmObject` for `(T, S)`](structure/manual_tasm_object_implementations.rs)                |
 |  230..300 | [`StarkVerify`](verifier/stark_verify.rs)                                                   |
 |  300..310 | [`vm_proof_iter::New`](verifier/vm_proof_iter/new.rs)                                       |
+|  310..320 | [`AddU64`](arithmetic/u64/add_u64.rs)                                                       |

--- a/tasm-lib/src/lib.rs
+++ b/tasm-lib/src/lib.rs
@@ -105,6 +105,20 @@ pub fn push_encodable<T: BFieldCodec>(stack: &mut Vec<BFieldElement>, value: &T)
     stack.extend(value.encode().into_iter().rev());
 }
 
+/// Pops an element of the specified, generic type from the stack.
+///
+/// ### Panics
+///
+/// Panics if
+/// - the generic type has [dynamic length](BFieldCodec::static_length)
+/// - the stack does not contain enough elements
+#[cfg(test)]
+pub(crate) fn pop_encodable<T: BFieldCodec>(stack: &mut Vec<BFieldElement>) -> T {
+    let len = T::static_length().unwrap();
+    let limbs = (0..len).map(|_| stack.pop().unwrap()).collect_vec();
+    *T::decode(&limbs).unwrap()
+}
+
 /// Execute a Triton-VM program and return its output and execution trace length
 pub fn execute_bench_deprecated(
     code: &[LabelledInstruction],


### PR DESCRIPTION
Remove its implementation of `DeprecatedSnippet`.

Also, use `pick` & `place` over `swap` for marginally more efficient stack manipulation.