### PR TITLE
refactor!: `TasmObject` is `BFieldCodec` subtrait

### DIFF
--- a/tasm-lib/src/structure/auto_generated_tasm_object_implementations.rs
+++ b/tasm-lib/src/structure/auto_generated_tasm_object_implementations.rs
@@ -14,7 +14,7 @@ use crate::twenty_first::util_types::mmr::mmr_successor_proof::MmrSuccessorProof
 
 macro_rules! derive_tasm_object_for {
     ($actual:ident using $fake:ident {$($field:ident: $field_type:ty,)* $(,)?}) => {
-        #[derive(TasmObject)]
+        #[derive(BFieldCodec, TasmObject)]
         struct $fake { $($field: $field_type),* }
 
         impl TasmObject for $actual {
@@ -80,7 +80,7 @@ derive_tasm_object_for!(
 
 // can't use macro: MmrAccumulator has private fields and uses a dedicated
 // constructor
-#[derive(TasmObject)]
+#[derive(BFieldCodec, TasmObject)]
 struct FakeMmrAccumulator {
     leaf_count: u64,
     peaks: Vec<Digest>,

--- a/tasm-lib/src/structure/tasm_object.rs
+++ b/tasm-lib/src/structure/tasm_object.rs
@@ -18,7 +18,7 @@ pub const DEFAULT_MAX_DYN_FIELD_SIZE: u32 = 1u32 << 28;
 ///
 /// The arguments referring to fields are strings. For structs with unnamed fields, the
 /// nth field name is implicitly `field_n`.
-pub trait TasmObject {
+pub trait TasmObject: BFieldCodec {
     /// Maximum jump distance for encoded size and length indicators.
     /// The field getters will compare any length or size indicator read
     /// from memory against this value and crash the VM if the indicator


### PR DESCRIPTION
All derived and any proper implementations of the trait `TasmObject` assume that the struct can be encoded according to the rules of `BFieldCodec`. Make this currently implicit assumption explicit.