### PR TITLE
Make 32-bit architecture compatible

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,49 @@
+name: WASM
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions: { }
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  wasm:
+    name: Build, lint, test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install stable toolchain
+        run: rustup install
+
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '20'
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2.77.7
+        with:
+          tool: wasm-pack
+
+      - name: Build with wasm-pack
+        working-directory: tasm-lib
+        run: wasm-pack build --release --target nodejs
+
+      - name: Run wasm-pack tests
+        working-directory: tasm-lib
+        run: wasm-pack test --node

--- a/tasm-lib/Cargo.toml
+++ b/tasm-lib/Cargo.toml
@@ -17,11 +17,22 @@ documentation.workspace = true
 repository.workspace = true
 readme.workspace = true
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dev-dependencies]
-proptest = "1.6"
-proptest-arbitrary-interop = "0.1"
+macro_rules_attr = "0.1.3"
+proptest = { version = "1.11", default-features = false, features = ["std"] }
+proptest-arbitrary-adapter = "0.1"
 rayon = "1"
-test-strategy = "0.4"
+test-strategy = "0.4.5"
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3.42"
+
+# Workaround for Rust 1.87.0 (see also: <https://github.com/rust-lang/rust/issues/141048>)
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O4", "--enable-bulk-memory"]
 
 [dependencies]
 anyhow = "1"
@@ -37,7 +48,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 strum = { version = "0.27", features = ["derive"] }
 tasm-object-derive.workspace = true
-triton-vm = { version = "2.0.0", default-features = false }
+triton-vm = { version = "3.0.0", default-features = false }
+web-time = "1.1"
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/tasm-lib/src/arithmetic/bfe/primitive_root_of_unity.rs
+++ b/tasm-lib/src/arithmetic/bfe/primitive_root_of_unity.rs
@@ -216,7 +216,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn primitive_root_of_order_2_pow_32_is_not_a_legal_order() {
         let root = BFieldElement::primitive_root_of_unity(1 << 32).unwrap();
 
@@ -224,7 +224,7 @@ mod tests {
         assert!(BFieldElement::primitive_root_of_unity(root.value()).is_none());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn all_primitive_roots_are_either_1_or_larger_than_u32_max() {
         for pow in 1..=32 {
             let root = BFieldElement::primitive_root_of_unity(1 << pow)
@@ -236,12 +236,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn primitive_root_of_unity_pbt() {
         ShadowedClosure::new(PrimitiveRootOfUnity).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn primitive_root_of_unity_unit_test() {
         for log2_order in 1..=32 {
             let order = 1u64 << log2_order;
@@ -263,7 +263,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn primitive_root_negative_test() {
         let small_non_powers_of_two = (0_u64..100).filter(|x| !x.is_power_of_two());
         let larger_non_powers_of_two = (1_u64..50).map(|x| (1 << 32) - x);
@@ -285,7 +285,7 @@ mod tests {
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn triton_vm_crashes_if_order_lo_is_not_u32(
         #[strategy(1_u8..=32)] log_2_order: u8,
         #[strategy(0..=u32::MAX)]
@@ -311,7 +311,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(PrimitiveRootOfUnity).bench()
     }

--- a/tasm-lib/src/arithmetic/bfe/primitive_root_of_unity.rs
+++ b/tasm-lib/src/arithmetic/bfe/primitive_root_of_unity.rs
@@ -195,12 +195,17 @@ mod tests {
     impl Closure for PrimitiveRootOfUnity {
         type Args = u64;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let order = pop_encodable::<Self::Args>(stack);
-            assert!(!order.is_zero(), "No root of order 0 exists");
-
-            let root_of_unity = BFieldElement::primitive_root_of_unity(order).unwrap();
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let order = pop_encodable::<Self::Args>(stack)?;
+            if order.is_zero() {
+                // no root of order 0 exists
+                return Err(RustShadowError::Other);
+            }
+            let root_of_unity =
+                BFieldElement::primitive_root_of_unity(order).ok_or(RustShadowError::Other)?;
             stack.push(root_of_unity);
+
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/i128/lt.rs
+++ b/tasm-lib/src/arithmetic/i128/lt.rs
@@ -129,12 +129,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn i128_lt_proptest() {
         ShadowedClosure::new(Lt).test();
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn input_not_u32_words_negative_test(
         #[strategy(0usize..8)] stack_index_bad_word: usize,
         #[strategy(arb())]
@@ -161,7 +161,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn i128_lt_unit_test_min_max() {
         let init_stack = Lt.set_up_test_stack((i128::MAX, i128::MIN));
         let mut expected_end_stack = Lt.init_stack_for_isolated_run();
@@ -178,7 +178,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn i128_lt_unit_test_zero_zero() {
         let init_stack = Lt.set_up_test_stack((0, 0));
         let mut expected_end_stack = Lt.init_stack_for_isolated_run();
@@ -195,7 +195,7 @@ mod tests {
         );
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn equal_elements_are_not_lt_prop(value: i128) {
         let init_stack = Lt.set_up_test_stack((value, value));
         let mut expected_end_stack = Lt.init_stack_for_isolated_run();
@@ -218,7 +218,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(Lt).bench();
     }

--- a/tasm-lib/src/arithmetic/i128/lt.rs
+++ b/tasm-lib/src/arithmetic/i128/lt.rs
@@ -91,9 +91,10 @@ mod tests {
     impl Closure for Lt {
         type Args = (i128, i128);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (rhs, lhs) = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (rhs, lhs) = pop_encodable::<Self::Args>(stack)?;
             push_encodable(stack, &(lhs < rhs));
+            Ok(())
         }
 
         fn pseudorandom_args(&self, seed: [u8; 32], _: Option<BenchmarkCase>) -> Self::Args {

--- a/tasm-lib/src/arithmetic/i128/shift_right.rs
+++ b/tasm-lib/src/arithmetic/i128/shift_right.rs
@@ -253,7 +253,7 @@ mod tests {
             let initial_stack = self.set_up_test_stack((arg, shamt));
 
             let mut expected_stack = initial_stack.clone();
-            self.rust_shadow(&mut expected_stack);
+            self.rust_shadow(&mut expected_stack).unwrap();
 
             test_rust_equivalence_given_complete_state(
                 &ShadowedClosure::new(Self),
@@ -269,9 +269,10 @@ mod tests {
     impl Closure for ShiftRight {
         type Args = (i128, u32);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (arg, shift_amount) = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (arg, shift_amount) = pop_encodable::<Self::Args>(stack)?;
             push_encodable(stack, &(arg >> shift_amount));
+            Ok(())
         }
 
         fn pseudorandom_args(&self, seed: [u8; 32], _: Option<BenchmarkCase>) -> Self::Args {
@@ -319,10 +320,11 @@ mod tests {
             &[],
             NonDeterminism::default(),
             &None,
-        );
+        )
+        .unwrap();
 
         let final_stack = &mut final_state.op_stack.stack;
-        let num_bits_in_result = pop_encodable::<i128>(final_stack).count_ones();
+        let num_bits_in_result = pop_encodable::<i128>(final_stack).unwrap().count_ones();
 
         if arg.is_positive() {
             prop_assert_eq!(0, num_bits_in_result);

--- a/tasm-lib/src/arithmetic/i128/shift_right.rs
+++ b/tasm-lib/src/arithmetic/i128/shift_right.rs
@@ -280,17 +280,17 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn standard_test() {
         ShadowedClosure::new(ShiftRight).test()
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn proptest(#[strategy(arb())] arg: i128, #[strategy(0u32..128)] shamt: u32) {
         ShiftRight.assert_expected_shift_behavior(arg, shamt);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_edge_cases() {
         // all i128s from all combinations of {-1, 0, 1} as their limbs
         let arguments = (0..4)
@@ -311,7 +311,7 @@ mod tests {
 
     /// Shifting right by 127 must produce either 0xff..f, or 0x00..0, depending on
     /// the sign of the i128-argument.
-    #[proptest(cases = 50)]
+    #[macro_rules_attr::apply(proptest(cases = 50))]
     fn shifting_right_by_127_is_zero_or_minus_1(arg: i128) {
         let mut final_state = tasm_final_state(
             &ShadowedClosure::new(ShiftRight),
@@ -337,7 +337,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(ShiftRight).bench()
     }

--- a/tasm-lib/src/arithmetic/u128/lt.rs
+++ b/tasm-lib/src/arithmetic/u128/lt.rs
@@ -108,7 +108,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn lt_u128_standard_test() {
         ShadowedClosure::new(Lt).test()
     }
@@ -118,13 +118,13 @@ mod tests {
         test_rust_equivalence_given_execution_state(&ShadowedClosure::new(Lt), initial_state);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn lt_u128_unit_test() {
         test_rust_tasm_equivalence(1 << 64, 1 << 32);
         test_rust_tasm_equivalence(1 << 32, 1 << 64);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn lt_u128_edge_cases_test() {
         let boundary_points = [0, 1 << 32, 1 << 64, 1 << 96, u128::MAX]
             .into_iter()
@@ -137,12 +137,12 @@ mod tests {
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn lt_u128_randomized_test_identical_args(v: u128) {
         test_rust_tasm_equivalence(v, v);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn lt_u128_randomized_test_identical_top_limbs(left: u128, right: u128) {
         test_rust_tasm_equivalence(left, replace_bottom_n_bits::<32>(left, right));
         test_rust_tasm_equivalence(left, replace_bottom_n_bits::<64>(left, right));
@@ -157,7 +157,7 @@ mod tests {
         ((left >> N) << N) | (right & bottom_bits_mask)
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bit_replacement_works_as_expected() {
         const fn abcd0xf<const N: u8>() -> u128 {
             replace_bottom_n_bits::<N>(0xaaaa_aaaa_bbbb_bbbb_cccc_cccc_dddd_dddd, u128::MAX)
@@ -176,7 +176,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(Lt).bench()
     }

--- a/tasm-lib/src/arithmetic/u128/lt.rs
+++ b/tasm-lib/src/arithmetic/u128/lt.rs
@@ -98,9 +98,10 @@ mod tests {
     impl Closure for Lt {
         type Args = (u128, u128);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (right, left) = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (right, left) = pop_encodable::<Self::Args>(stack)?;
             push_encodable(stack, &(left < right));
+            Ok(())
         }
 
         fn pseudorandom_args(&self, seed: [u8; 32], _: Option<BenchmarkCase>) -> Self::Args {

--- a/tasm-lib/src/arithmetic/u128/overflowing_add.rs
+++ b/tasm-lib/src/arithmetic/u128/overflowing_add.rs
@@ -101,7 +101,7 @@ pub(crate) mod tests {
             let initial_stack = self.set_up_test_stack((rhs, lhs));
 
             let mut expected_stack = initial_stack.clone();
-            self.rust_shadow(&mut expected_stack);
+            self.rust_shadow(&mut expected_stack).unwrap();
 
             test_rust_equivalence_given_complete_state(
                 &ShadowedClosure::new(Self),
@@ -125,11 +125,12 @@ pub(crate) mod tests {
     impl Closure for OverflowingAdd {
         type Args = (u128, u128);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (left, right) = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (left, right) = pop_encodable::<Self::Args>(stack)?;
             let (sum, is_overflow) = left.overflowing_add(right);
             push_encodable(stack, &sum);
             push_encodable(stack, &is_overflow);
+            Ok(())
         }
 
         fn pseudorandom_args(&self, seed: [u8; 32], _: Option<BenchmarkCase>) -> Self::Args {
@@ -148,8 +149,9 @@ pub(crate) mod tests {
     }
 
     #[macro_rules_attr::apply(test)]
-    fn rust_shadow() {
+    fn rust_shadow() -> Result<(), RustShadowError> {
         ShadowedClosure::new(OverflowingAdd).test();
+        Ok(())
     }
 
     #[macro_rules_attr::apply(test)]

--- a/tasm-lib/src/arithmetic/u128/overflowing_add.rs
+++ b/tasm-lib/src/arithmetic/u128/overflowing_add.rs
@@ -147,18 +147,18 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(OverflowingAdd).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn unit_test() {
         let snippet = OverflowingAdd;
         snippet.assert_expected_add_behavior(1u128 << 67, 1u128 << 67)
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn overflow_test() {
         let test_overflowing_add = |a, b| {
             OverflowingAdd.assert_expected_add_behavior(a, b);
@@ -189,7 +189,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(OverflowingAdd).bench();
     }

--- a/tasm-lib/src/arithmetic/u128/safe_add.rs
+++ b/tasm-lib/src/arithmetic/u128/safe_add.rs
@@ -100,17 +100,17 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(SafeAdd).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn unit_test() {
         SafeAdd.assert_expected_add_behavior(1 << 67, 1 << 67)
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn overflow_test() {
         for args in [
             (1 << 127, 1 << 127),
@@ -156,7 +156,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(SafeAdd).bench()
     }

--- a/tasm-lib/src/arithmetic/u128/safe_add.rs
+++ b/tasm-lib/src/arithmetic/u128/safe_add.rs
@@ -58,7 +58,7 @@ mod tests {
             let initial_stack = self.set_up_test_stack((lhs, rhs));
 
             let mut expected_stack = initial_stack.clone();
-            self.rust_shadow(&mut expected_stack);
+            self.rust_shadow(&mut expected_stack).unwrap();
 
             test_rust_equivalence_given_complete_state(
                 &ShadowedClosure::new(Self),
@@ -74,10 +74,13 @@ mod tests {
     impl Closure for SafeAdd {
         type Args = <OverflowingAdd as Closure>::Args;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (left, right) = pop_encodable::<Self::Args>(stack);
-            let sum = left.checked_add(right).unwrap();
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (left, right) = pop_encodable::<Self::Args>(stack)?;
+            let sum = left
+                .checked_add(right)
+                .ok_or(RustShadowError::ArithmeticOverflow)?;
             push_encodable(stack, &sum);
+            Ok(())
         }
 
         fn pseudorandom_args(&self, seed: [u8; 32], _: Option<BenchmarkCase>) -> Self::Args {

--- a/tasm-lib/src/arithmetic/u128/safe_mul.rs
+++ b/tasm-lib/src/arithmetic/u128/safe_mul.rs
@@ -253,12 +253,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(SafeMul).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn overflow_crashes_vm() {
         SafeMul.test_assertion_failure(1 << 127, 1 << 1, &[500]);
         SafeMul.test_assertion_failure(1 << 96, 1 << 32, &[501]);
@@ -282,7 +282,7 @@ mod tests {
         }
     }
 
-    #[proptest(cases = 80)]
+    #[macro_rules_attr::apply(proptest(cases = 80))]
     fn arbitrary_overflow_crashes_vm(
         #[strategy(2_u8..128)] _log_upper_bound: u8,
         #[strategy(2_u128..(1 << #_log_upper_bound))] left: u128,
@@ -291,7 +291,7 @@ mod tests {
         SafeMul.test_assertion_failure(left, right, &[500, 501, 502, 503, 504, 505, 506]);
     }
 
-    #[proptest(cases = 80)]
+    #[macro_rules_attr::apply(proptest(cases = 80))]
     fn marginal_overflow_crashes_vm(
         #[strategy(2_u8..128)] _log_upper_bound: u8,
         #[strategy(2_u128..(1 << #_log_upper_bound))] left: u128,
@@ -300,7 +300,7 @@ mod tests {
         SafeMul.test_assertion_failure(left, right, &[500, 501, 502, 503, 504, 505, 506]);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn arbitrary_overflow_crashes_vm_u128(
         #[strategy(2_u128..)] left: u128,
         #[strategy(u128::MAX / #left + 1..)] right: u128,
@@ -314,7 +314,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(SafeMul).bench();
     }

--- a/tasm-lib/src/arithmetic/u128/safe_mul.rs
+++ b/tasm-lib/src/arithmetic/u128/safe_mul.rs
@@ -210,10 +210,13 @@ mod tests {
     impl Closure for SafeMul {
         type Args = (u128, u128);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (right, left) = pop_encodable::<Self::Args>(stack);
-            let product = left.checked_mul(right).unwrap();
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (right, left) = pop_encodable::<Self::Args>(stack)?;
+            let product = left
+                .checked_mul(right)
+                .ok_or(RustShadowError::ArithmeticOverflow)?;
             push_encodable(stack, &product);
+            Ok(())
         }
 
         fn pseudorandom_args(
@@ -255,7 +258,7 @@ mod tests {
 
     #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
-        ShadowedClosure::new(SafeMul).test();
+        ShadowedClosure::new(SafeMul).test()
     }
 
     #[macro_rules_attr::apply(test)]

--- a/tasm-lib/src/arithmetic/u128/shift_left.rs
+++ b/tasm-lib/src/arithmetic/u128/shift_left.rs
@@ -136,10 +136,13 @@ mod tests {
     impl Closure for ShiftLeft {
         type Args = <ShiftRight as Closure>::Args;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (arg, shift_amount) = pop_encodable::<Self::Args>(stack);
-            assert!(shift_amount < 128);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (arg, shift_amount) = pop_encodable::<Self::Args>(stack)?;
+            if shift_amount >= 128 {
+                return Err(RustShadowError::ArithmeticOverflow);
+            }
             push_encodable(stack, &(arg << shift_amount));
+            Ok(())
         }
 
         fn pseudorandom_args(
@@ -163,7 +166,7 @@ mod tests {
 
     #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
-        ShadowedClosure::new(ShiftLeft).test();
+        ShadowedClosure::new(ShiftLeft).test()
     }
 
     #[macro_rules_attr::apply(proptest)]

--- a/tasm-lib/src/arithmetic/u128/shift_left.rs
+++ b/tasm-lib/src/arithmetic/u128/shift_left.rs
@@ -161,12 +161,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(ShiftLeft).test();
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn too_large_shift_crashes_vm(arg: u128, #[strategy(128_u32..)] shift_amount: u32) {
         test_assertion_failure(
             &ShadowedClosure::new(ShiftLeft),
@@ -181,7 +181,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(ShiftLeft).bench();
     }

--- a/tasm-lib/src/arithmetic/u128/shift_left_static.rs
+++ b/tasm-lib/src/arithmetic/u128/shift_left_static.rs
@@ -84,9 +84,10 @@ pub(crate) mod tests {
     impl<const N: u8> Closure for ShiftLeftStatic<N> {
         type Args = u128;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let v = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let v = pop_encodable::<Self::Args>(stack)?;
             push_encodable(stack, &(v << N));
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u128/shift_left_static.rs
+++ b/tasm-lib/src/arithmetic/u128/shift_left_static.rs
@@ -106,7 +106,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         macro_rules! test_shift_left_static {
             ($($i:expr),*$(,)?) => {
@@ -121,7 +121,7 @@ pub(crate) mod tests {
         test_shift_left_static!(32);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     #[should_panic]
     fn shift_beyond_limit() {
         ShadowedClosure::new(ShiftLeftStatic::<33>).test();
@@ -133,7 +133,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(ShiftLeftStatic::<5>).bench();
     }

--- a/tasm-lib/src/arithmetic/u128/shift_right.rs
+++ b/tasm-lib/src/arithmetic/u128/shift_right.rs
@@ -141,10 +141,13 @@ mod tests {
     impl Closure for ShiftRight {
         type Args = (u128, u32);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (arg, shift_amount) = pop_encodable::<Self::Args>(stack);
-            assert!(shift_amount < 128);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (arg, shift_amount) = pop_encodable::<Self::Args>(stack)?;
+            if shift_amount >= 128 {
+                return Err(RustShadowError::ArithmeticOverflow);
+            }
             push_encodable(stack, &(arg >> shift_amount));
+            Ok(())
         }
 
         fn pseudorandom_args(
@@ -171,7 +174,7 @@ mod tests {
 
     #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
-        ShadowedClosure::new(ShiftRight).test();
+        ShadowedClosure::new(ShiftRight).test()
     }
 
     #[macro_rules_attr::apply(proptest)]

--- a/tasm-lib/src/arithmetic/u128/shift_right.rs
+++ b/tasm-lib/src/arithmetic/u128/shift_right.rs
@@ -169,12 +169,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(ShiftRight).test();
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn too_large_shift_crashes_vm(arg: u128, #[strategy(128_u32..)] shift_amount: u32) {
         test_assertion_failure(
             &ShadowedClosure::new(ShiftRight),
@@ -189,7 +189,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(ShiftRight).bench();
     }

--- a/tasm-lib/src/arithmetic/u128/shift_right_static.rs
+++ b/tasm-lib/src/arithmetic/u128/shift_right_static.rs
@@ -85,9 +85,10 @@ mod tests {
     impl<const N: u8> Closure for ShiftRightStatic<N> {
         type Args = <ShiftLeftStatic<N> as Closure>::Args;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let v = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let v = pop_encodable::<Self::Args>(stack)?;
             push_encodable(stack, &(v >> N));
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u128/shift_right_static.rs
+++ b/tasm-lib/src/arithmetic/u128/shift_right_static.rs
@@ -103,7 +103,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         macro_rules! test_shift_right_static {
             ($($i:expr),*$(,)?) => {
@@ -118,7 +118,7 @@ mod tests {
         test_shift_right_static!(32);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     #[should_panic]
     fn shift_beyond_limit() {
         ShadowedClosure::new(ShiftRightStatic::<33>).test();
@@ -130,7 +130,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(ShiftRightStatic::<5>).bench();
     }

--- a/tasm-lib/src/arithmetic/u128/sub.rs
+++ b/tasm-lib/src/arithmetic/u128/sub.rs
@@ -161,12 +161,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(Sub).test();
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn overflow_crashes_vm(
         #[strategy(1_u128..)] subtrahend: u128,
         #[strategy(..#subtrahend)] minuend: u128,
@@ -184,7 +184,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(Sub).bench();
     }

--- a/tasm-lib/src/arithmetic/u128/sub.rs
+++ b/tasm-lib/src/arithmetic/u128/sub.rs
@@ -121,10 +121,13 @@ mod tests {
     impl Closure for Sub {
         type Args = (u128, u128);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (subtrahend, minuend) = pop_encodable::<Self::Args>(stack);
-            let difference = minuend.checked_sub(subtrahend).unwrap();
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (subtrahend, minuend) = pop_encodable::<Self::Args>(stack)?;
+            let difference = minuend
+                .checked_sub(subtrahend)
+                .ok_or(RustShadowError::ArithmeticOverflow)?;
             push_encodable(stack, &difference);
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u160/div_mod.rs
+++ b/tasm-lib/src/arithmetic/u160/div_mod.rs
@@ -342,38 +342,44 @@ mod tests {
         fn rust_shadow(
             &self,
             stack: &mut Vec<BFieldElement>,
-            memory: &mut std::collections::HashMap<BFieldElement, BFieldElement>,
+            memory: &mut HashMap<BFieldElement, BFieldElement>,
             nondeterminism: &NonDeterminism,
-        ) {
-            let denominator: [u32; 5] = pop_encodable(stack);
+        ) -> Result<(), RustShadowError> {
+            let denominator: [u32; 5] = pop_encodable(stack)?;
             let denominator: BigUint = BigUint::new(denominator.to_vec());
-            assert!(!denominator.is_zero());
+            if denominator.is_zero() {
+                return Err(RustShadowError::Other);
+            }
 
-            let numerator: [u32; 5] = pop_encodable(stack);
+            let numerator: [u32; 5] = pop_encodable(stack)?;
             let numerator: BigUint = BigUint::new(numerator.to_vec());
 
             let quotient = &nondeterminism.individual_tokens[0..5];
-            let mut quotient: [u32; 5] =
-                *TasmObject::decode_iter(&mut quotient.iter().cloned()).unwrap();
+            let mut quotient: [u32; 5] = *TasmObject::decode_iter(&mut quotient.iter().cloned())
+                .map_err(|_| RustShadowError::DecodingError)?;
             quotient.reverse();
             let quotient: BigUint = BigUint::new(quotient.to_vec());
 
             let remainder = &nondeterminism.individual_tokens[5..10];
-            let mut remainder: [u32; 5] =
-                *TasmObject::decode_iter(&mut remainder.iter().cloned()).unwrap();
+            let mut remainder: [u32; 5] = *TasmObject::decode_iter(&mut remainder.iter().cloned())
+                .map_err(|_| RustShadowError::DecodingError)?;
             remainder.reverse();
             let remainder: BigUint = BigUint::new(remainder.to_vec());
 
-            assert!(remainder < denominator);
-            assert!(numerator == quotient.clone() * denominator + remainder.clone());
+            if remainder >= denominator {
+                return Err(RustShadowError::Other);
+            }
+            if numerator != quotient.clone() * denominator + remainder.clone() {
+                return Err(RustShadowError::Other);
+            }
 
             let mut quotient = quotient.to_u32_digits();
             quotient.resize(5, 0);
-            let quotient: [u32; 5] = quotient.try_into().unwrap();
+            let quotient: [u32; 5] = quotient.try_into().map_err(|_| RustShadowError::Other)?;
 
             let mut remainder = remainder.to_u32_digits();
             remainder.resize(5, 0);
-            let remainder: [u32; 5] = remainder.try_into().unwrap();
+            let remainder: [u32; 5] = remainder.try_into().map_err(|_| RustShadowError::Other)?;
 
             // Imitate use of static memory
             encode_to_memory(memory, STATIC_MEMORY_FIRST_ADDRESS - bfe!(4), &remainder);
@@ -381,6 +387,7 @@ mod tests {
 
             push_encodable(stack, &quotient);
             push_encodable(stack, &remainder);
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/arithmetic/u160/div_mod.rs
+++ b/tasm-lib/src/arithmetic/u160/div_mod.rs
@@ -175,12 +175,12 @@ mod tests {
     use crate::test_prelude::Algorithm;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn std_test() {
         ShadowedAlgorithm::new(DivMod).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn too_big_remainder() {
         let numerator = 10;
         let denominator = 3;
@@ -204,7 +204,7 @@ mod tests {
         )
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn euler_equation_error() {
         let numerator = 1u128 << 99;
         let denominator = 1u128 << 45;
@@ -228,7 +228,7 @@ mod tests {
         )
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn division_by_zero() {
         let numerator = u128_to_u160(52);
         let denominator = u128_to_u160(0);
@@ -240,7 +240,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bad_encoding() {
         let not_u32 = bfe!(1u64 << 32);
         let valid_u32 = bfe!(14);
@@ -416,7 +416,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedAlgorithm::new(DivMod).bench()
     }

--- a/tasm-lib/src/arithmetic/u160/lt.rs
+++ b/tasm-lib/src/arithmetic/u160/lt.rs
@@ -92,13 +92,14 @@ mod tests {
     impl Closure for Lt {
         type Args = ([u32; 5], [u32; 5]);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let left: [u32; 5] = pop_encodable(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let left: [u32; 5] = pop_encodable(stack)?;
             let left: BigUint = BigUint::new(left.to_vec());
 
-            let right: [u32; 5] = pop_encodable(stack);
+            let right: [u32; 5] = pop_encodable(stack)?;
             let right: BigUint = BigUint::new(right.to_vec());
             push_encodable(stack, &(left < right));
+            Ok(())
         }
 
         fn pseudorandom_args(&self, seed: [u8; 32], _: Option<BenchmarkCase>) -> Self::Args {

--- a/tasm-lib/src/arithmetic/u160/lt.rs
+++ b/tasm-lib/src/arithmetic/u160/lt.rs
@@ -111,12 +111,12 @@ mod tests {
         test_rust_equivalence_given_execution_state(&ShadowedClosure::new(Lt), initial_state);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn lt_u160_standard_test() {
         ShadowedClosure::new(Lt).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn lt_u160_edge_cases_test() {
         let mut boundary_points = [0, 1 << 32, 1 << 64, 1 << 96, u128::MAX]
             .into_iter()
@@ -140,7 +140,7 @@ mod tests {
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn lt_u160_randomized_test_identical_args(v: [u32; 5]) {
         test_rust_tasm_equivalence(v, v);
     }
@@ -151,7 +151,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(Lt).bench()
     }

--- a/tasm-lib/src/arithmetic/u160/overflowing_add.rs
+++ b/tasm-lib/src/arithmetic/u160/overflowing_add.rs
@@ -108,7 +108,7 @@ pub(crate) mod tests {
             let initial_stack = self.set_up_test_stack((rhs, lhs));
 
             let mut expected_stack = initial_stack.clone();
-            self.rust_shadow(&mut expected_stack);
+            self.rust_shadow(&mut expected_stack).unwrap();
 
             test_rust_equivalence_given_complete_state(
                 &ShadowedClosure::new(Self),
@@ -134,17 +134,18 @@ pub(crate) mod tests {
     impl Closure for OverflowingAdd {
         type Args = ([u32; 5], [u32; 5]);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let left: [u32; 5] = pop_encodable(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let left: [u32; 5] = pop_encodable(stack)?;
             let left: BigUint = BigUint::new(left.to_vec());
-            let right: [u32; 5] = pop_encodable(stack);
+            let right: [u32; 5] = pop_encodable(stack)?;
             let right: BigUint = BigUint::new(right.to_vec());
             let sum = left + right;
             let mut sum = sum.to_u32_digits();
-            assert!(
-                sum.len() <= 5 || sum.len() == 6 && *sum.last().unwrap() == 1,
-                "Value must be bounded thusly"
-            );
+            let overflow_shape_is_valid =
+                sum.len() <= 5 || (sum.len() == 6 && sum.last().is_some_and(|&x| x == 1));
+            if !overflow_shape_is_valid {
+                return Err(RustShadowError::ArithmeticOverflow);
+            }
 
             let is_overflow = sum.len() == 6;
 
@@ -152,6 +153,7 @@ pub(crate) mod tests {
             let sum: [u32; 5] = sum.to_vec().try_into().unwrap();
             push_encodable(stack, &sum);
             push_encodable(stack, &is_overflow);
+            Ok(())
         }
 
         fn pseudorandom_args(&self, seed: [u8; 32], _: Option<BenchmarkCase>) -> Self::Args {
@@ -171,7 +173,7 @@ pub(crate) mod tests {
 
     #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
-        ShadowedClosure::new(OverflowingAdd).test();
+        ShadowedClosure::new(OverflowingAdd).test()
     }
 
     #[macro_rules_attr::apply(test)]

--- a/tasm-lib/src/arithmetic/u160/overflowing_add.rs
+++ b/tasm-lib/src/arithmetic/u160/overflowing_add.rs
@@ -169,18 +169,18 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(OverflowingAdd).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn unit_test() {
         let snippet = OverflowingAdd;
         snippet.assert_expected_add_behavior(u128_to_u160(1u128 << 67), u128_to_u160(1u128 << 67))
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn overflow_test() {
         let test_overflowing_add = |a, b| {
             OverflowingAdd.assert_expected_add_behavior(a, b);

--- a/tasm-lib/src/arithmetic/u160/safe_add.rs
+++ b/tasm-lib/src/arithmetic/u160/safe_add.rs
@@ -73,12 +73,12 @@ mod tests {
     use crate::arithmetic::u160::u128_to_u160_shl_32_lower_limb_filled;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(SafeAdd).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn overflow_test() {
         for (left, right) in [
             (1 << 127, 1 << 127),
@@ -203,7 +203,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(SafeAdd).bench()
     }

--- a/tasm-lib/src/arithmetic/u160/safe_add.rs
+++ b/tasm-lib/src/arithmetic/u160/safe_add.rs
@@ -131,19 +131,22 @@ mod tests {
     impl Closure for SafeAdd {
         type Args = <OverflowingAdd as Closure>::Args;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let left: [u32; 5] = pop_encodable(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let left: [u32; 5] = pop_encodable(stack)?;
             let left: BigUint = BigUint::new(left.to_vec());
-            let right: [u32; 5] = pop_encodable(stack);
+            let right: [u32; 5] = pop_encodable(stack)?;
             let right: BigUint = BigUint::new(right.to_vec());
             let sum = left + right;
             let mut sum = sum.to_u32_digits();
-            assert!(sum.len() <= 5, "Overflow");
+            if sum.len() > 5 {
+                return Err(RustShadowError::ArithmeticOverflow);
+            }
 
             sum.resize(5, 0);
             let sum: [u32; 5] = sum.try_into().unwrap();
 
             push_encodable(stack, &sum);
+            Ok(())
         }
 
         fn pseudorandom_args(&self, seed: [u8; 32], _: Option<BenchmarkCase>) -> Self::Args {

--- a/tasm-lib/src/arithmetic/u160/safe_mul.rs
+++ b/tasm-lib/src/arithmetic/u160/safe_mul.rs
@@ -374,19 +374,23 @@ mod tests {
     impl Closure for SafeMul {
         type Args = ([u32; 5], [u32; 5]);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let left: [u32; 5] = pop_encodable(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let left: [u32; 5] = pop_encodable(stack)?;
             let left: BigUint = BigUint::new(left.to_vec());
-            let right: [u32; 5] = pop_encodable(stack);
+            let right: [u32; 5] = pop_encodable(stack)?;
             let right: BigUint = BigUint::new(right.to_vec());
             let prod = left.clone() * right.clone();
             let mut prod = prod.to_u32_digits();
-            assert!(prod.len() <= 5, "Overflow: left: {left}, right: {right}.");
+            if prod.len() > 5 {
+                eprintln!("Overflow: left: {left}, right: {right}.");
+                return Err(RustShadowError::ArithmeticOverflow);
+            }
 
             prod.resize(5, 0);
             let prod: [u32; 5] = prod.try_into().unwrap();
 
             push_encodable(stack, &prod);
+            Ok(())
         }
 
         fn pseudorandom_args(&self, seed: [u8; 32], _: Option<BenchmarkCase>) -> Self::Args {

--- a/tasm-lib/src/arithmetic/u160/safe_mul.rs
+++ b/tasm-lib/src/arithmetic/u160/safe_mul.rs
@@ -254,12 +254,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(SafeMul).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn overflow_unit_test() {
         SafeMul.test_assertion_failure(
             u128_to_u160_shl_32(u128::MAX),
@@ -300,7 +300,7 @@ mod tests {
         SafeMul.test_assertion_failure(u128_to_u160_shl_32(1 << 127), u128_to_u160(2), &[583]);
     }
 
-    #[proptest(cases = 100)]
+    #[macro_rules_attr::apply(proptest(cases = 100))]
     fn arbitrary_overflow_crashes_vm_u128(
         #[strategy(2_u128..)] left: u128,
         #[strategy(u128::MAX / #left + 1..)] right: u128,
@@ -310,7 +310,7 @@ mod tests {
         SafeMul.test_assertion_failure(left, right, &[580, 581, 582, 583, 584, 570]);
     }
 
-    #[proptest(cases = 50)]
+    #[macro_rules_attr::apply(proptest(cases = 50))]
     fn marginal_overflow_crashes_vm(
         #[strategy(2_u8..128)] _log_upper_bound: u8,
         #[strategy(2_u128..(1 << #_log_upper_bound))] left: u128,
@@ -330,7 +330,7 @@ mod tests {
         );
     }
 
-    #[proptest(cases = 50)]
+    #[macro_rules_attr::apply(proptest(cases = 50))]
     fn arbitrary_overflow_crashes_vm(
         #[strategy(2_u8..128)] _log_upper_bound: u8,
         #[strategy(2_u128..(1 << #_log_upper_bound))] left: u128,
@@ -476,7 +476,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(SafeMul).bench()
     }

--- a/tasm-lib/src/arithmetic/u192/overflowing_add.rs
+++ b/tasm-lib/src/arithmetic/u192/overflowing_add.rs
@@ -116,7 +116,7 @@ pub(crate) mod tests {
             let initial_stack = self.set_up_test_stack((rhs, lhs));
 
             let mut expected_stack = initial_stack.clone();
-            self.rust_shadow(&mut expected_stack);
+            self.rust_shadow(&mut expected_stack).unwrap();
 
             test_rust_equivalence_given_complete_state(
                 &ShadowedClosure::new(Self),
@@ -147,17 +147,18 @@ pub(crate) mod tests {
     impl Closure for OverflowingAdd {
         type Args = (U192, U192);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let left: U192 = pop_encodable(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let left: U192 = pop_encodable(stack)?;
             let left: BigUint = BigUint::new(left.to_vec());
-            let right: U192 = pop_encodable(stack);
+            let right: U192 = pop_encodable(stack)?;
             let right: BigUint = BigUint::new(right.to_vec());
             let sum = left + right;
             let mut sum = sum.to_u32_digits();
-            assert!(
-                sum.len() <= 6 || sum.len() == 7 && *sum.last().unwrap() == 1,
-                "Value must be bounded thusly"
-            );
+            let overflow_shape_is_valid =
+                sum.len() <= 6 || (sum.len() == 7 && sum.last().copied().is_some_and(|x| x == 1));
+            if !overflow_shape_is_valid {
+                return Err(RustShadowError::Other);
+            }
 
             let is_overflow = sum.len() == 7;
 
@@ -165,6 +166,7 @@ pub(crate) mod tests {
             let sum: U192 = sum.to_vec().try_into().unwrap();
             push_encodable(stack, &sum);
             push_encodable(stack, &is_overflow);
+            Ok(())
         }
 
         fn pseudorandom_args(&self, seed: [u8; 32], _: Option<BenchmarkCase>) -> Self::Args {
@@ -184,7 +186,7 @@ pub(crate) mod tests {
 
     #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
-        ShadowedClosure::new(OverflowingAdd).test();
+        ShadowedClosure::new(OverflowingAdd).test()
     }
 
     #[macro_rules_attr::apply(test)]

--- a/tasm-lib/src/arithmetic/u192/overflowing_add.rs
+++ b/tasm-lib/src/arithmetic/u192/overflowing_add.rs
@@ -182,18 +182,18 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(OverflowingAdd).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn unit_test() {
         let snippet = OverflowingAdd;
         snippet.assert_expected_add_behavior(u128_to_u192(1u128 << 67), u128_to_u192(1u128 << 67))
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn overflow_test() {
         let test_overflowing_add = |a, b| {
             OverflowingAdd.assert_expected_add_behavior(a, b);

--- a/tasm-lib/src/arithmetic/u192/safe_add.rs
+++ b/tasm-lib/src/arithmetic/u192/safe_add.rs
@@ -74,12 +74,12 @@ mod tests {
     use crate::arithmetic::u192::u128_to_u192_shl64;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(SafeAdd).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn overflow_test() {
         for (left, right) in [
             (1 << 127, 1 << 127),
@@ -204,7 +204,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(SafeAdd).bench()
     }

--- a/tasm-lib/src/arithmetic/u192/safe_add.rs
+++ b/tasm-lib/src/arithmetic/u192/safe_add.rs
@@ -76,7 +76,7 @@ mod tests {
 
     #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
-        ShadowedClosure::new(SafeAdd).test()
+        ShadowedClosure::new(SafeAdd).test();
     }
 
     #[macro_rules_attr::apply(test)]
@@ -132,19 +132,22 @@ mod tests {
     impl Closure for SafeAdd {
         type Args = <OverflowingAdd as Closure>::Args;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let left: U192 = pop_encodable(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let left: U192 = pop_encodable(stack)?;
             let left: BigUint = BigUint::new(left.to_vec());
-            let right: U192 = pop_encodable(stack);
+            let right: U192 = pop_encodable(stack)?;
             let right: BigUint = BigUint::new(right.to_vec());
             let sum = left + right;
             let mut sum = sum.to_u32_digits();
-            assert!(sum.len() <= 6, "Overflow");
+            if sum.len() > 6 {
+                return Err(RustShadowError::ArithmeticOverflow);
+            }
 
             sum.resize(6, 0);
             let sum: U192 = sum.try_into().unwrap();
 
             push_encodable(stack, &sum);
+            Ok(())
         }
 
         fn pseudorandom_args(&self, seed: [u8; 32], _: Option<BenchmarkCase>) -> Self::Args {

--- a/tasm-lib/src/arithmetic/u32/is_odd.rs
+++ b/tasm-lib/src/arithmetic/u32/is_odd.rs
@@ -90,7 +90,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(IsOdd).test();
     }
@@ -101,7 +101,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(IsOdd).bench();
     }

--- a/tasm-lib/src/arithmetic/u32/is_odd.rs
+++ b/tasm-lib/src/arithmetic/u32/is_odd.rs
@@ -67,10 +67,11 @@ mod tests {
     impl Closure for IsOdd {
         type Args = u32;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let v = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let v = pop_encodable::<Self::Args>(stack)?;
             let is_odd = v % 2 == 1;
             push_encodable(stack, &is_odd);
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u32/is_u32.rs
+++ b/tasm-lib/src/arithmetic/u32/is_u32.rs
@@ -65,10 +65,11 @@ mod tests {
     impl Closure for IsU32 {
         type Args = BFieldElement;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let value = stack.pop().unwrap();
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let value = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
             let is_u32 = u32::try_from(value).is_ok();
             push_encodable(stack, &is_u32);
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u32/is_u32.rs
+++ b/tasm-lib/src/arithmetic/u32/is_u32.rs
@@ -88,7 +88,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(IsU32).test();
     }
@@ -99,7 +99,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn is_u32_benchmark() {
         ShadowedClosure::new(IsU32).bench();
     }

--- a/tasm-lib/src/arithmetic/u32/leading_zeros.rs
+++ b/tasm-lib/src/arithmetic/u32/leading_zeros.rs
@@ -74,7 +74,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn unit() {
         ShadowedClosure::new(LeadingZeros).test();
     }
@@ -85,7 +85,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(LeadingZeros).bench();
     }

--- a/tasm-lib/src/arithmetic/u32/leading_zeros.rs
+++ b/tasm-lib/src/arithmetic/u32/leading_zeros.rs
@@ -52,9 +52,10 @@ mod tests {
     impl Closure for LeadingZeros {
         type Args = u32;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let arg = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let arg = pop_encodable::<Self::Args>(stack)?;
             push_encodable(stack, &arg.leading_zeros());
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u32/next_power_of_two.rs
+++ b/tasm-lib/src/arithmetic/u32/next_power_of_two.rs
@@ -121,9 +121,14 @@ mod tests {
     impl Closure for NextPowerOfTwo {
         type Args = u32;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let arg = pop_encodable::<Self::Args>(stack);
-            push_encodable(stack, &arg.next_power_of_two());
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let arg = pop_encodable::<Self::Args>(stack)?;
+            let pow = arg
+                .checked_next_power_of_two()
+                .ok_or(RustShadowError::ArithmeticOverflow)?;
+            push_encodable(stack, &pow);
+
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u32/next_power_of_two.rs
+++ b/tasm-lib/src/arithmetic/u32/next_power_of_two.rs
@@ -152,12 +152,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn next_power_of_two_pbt() {
         ShadowedClosure::new(NextPowerOfTwo).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn npo2_overflow_negative_test() {
         let greater_two_pow_31 = (1..=5).map(|i| (1 << 31) + i);
         let smaller_equal_u32_max = (0..=2).map(|i| u32::MAX - i);
@@ -177,7 +177,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(NextPowerOfTwo).bench()
     }

--- a/tasm-lib/src/arithmetic/u32/or.rs
+++ b/tasm-lib/src/arithmetic/u32/or.rs
@@ -73,10 +73,11 @@ mod tests {
     impl Closure for Or {
         type Args = (u32, u32);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (right, left) = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (right, left) = pop_encodable::<Self::Args>(stack)?;
             let or = left | right;
             push_encodable(stack, &or);
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u32/or.rs
+++ b/tasm-lib/src/arithmetic/u32/or.rs
@@ -98,7 +98,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(Or).test();
     }
@@ -109,7 +109,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(Or).bench();
     }

--- a/tasm-lib/src/arithmetic/u32/overflowing_add.rs
+++ b/tasm-lib/src/arithmetic/u32/overflowing_add.rs
@@ -64,12 +64,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn u32_overflowing_add_pbt() {
         ShadowedClosure::new(OverflowingAdd).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn u32_overflowing_add_unit_test() {
         for (lhs, rhs) in [
             (0, 0),
@@ -102,7 +102,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(OverflowingAdd).bench()
     }

--- a/tasm-lib/src/arithmetic/u32/overflowing_add.rs
+++ b/tasm-lib/src/arithmetic/u32/overflowing_add.rs
@@ -43,12 +43,13 @@ mod tests {
     impl Closure for OverflowingAdd {
         type Args = (u32, u32);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (left, right) = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (left, right) = pop_encodable::<Self::Args>(stack)?;
             let (sum, is_overflow) = left.overflowing_add(right);
 
             push_encodable(stack, &sum);
             push_encodable(stack, &is_overflow);
+            Ok(())
         }
 
         fn pseudorandom_args(
@@ -83,7 +84,9 @@ mod tests {
             let initial_stack = OverflowingAdd.set_up_test_stack((lhs, rhs));
 
             let mut expected_final_stack = initial_stack.clone();
-            OverflowingAdd.rust_shadow(&mut expected_final_stack);
+            OverflowingAdd
+                .rust_shadow(&mut expected_final_stack)
+                .unwrap();
 
             let _vm_output_state = test_rust_equivalence_given_complete_state(
                 &ShadowedClosure::new(OverflowingAdd),

--- a/tasm-lib/src/arithmetic/u32/safe_add.rs
+++ b/tasm-lib/src/arithmetic/u32/safe_add.rs
@@ -105,12 +105,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(SafeAdd).test();
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn overflow_crashes_vm(
         #[filter(#left != 0)] left: u32,
         #[strategy(u32::MAX - #left + 1..)] right: u32,
@@ -129,7 +129,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn safe_add_benchmark() {
         ShadowedClosure::new(SafeAdd).bench();
     }

--- a/tasm-lib/src/arithmetic/u32/safe_add.rs
+++ b/tasm-lib/src/arithmetic/u32/safe_add.rs
@@ -75,10 +75,13 @@ mod tests {
     impl Closure for SafeAdd {
         type Args = (u32, u32);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (right, left) = pop_encodable::<Self::Args>(stack);
-            let sum = left.checked_add(right).unwrap();
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (right, left) = pop_encodable::<Self::Args>(stack)?;
+            let sum = left
+                .checked_add(right)
+                .ok_or(RustShadowError::ArithmeticOverflow)?;
             push_encodable(stack, &sum);
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u32/safe_mul.rs
+++ b/tasm-lib/src/arithmetic/u32/safe_mul.rs
@@ -110,12 +110,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(SafeMul).test();
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn overflow_crashes_vm(
         #[strategy(1_u32..)] left: u32,
         #[strategy(u32::MAX / #left..)]
@@ -135,7 +135,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn safe_mul_benchmark() {
         ShadowedClosure::new(SafeMul).bench();
     }

--- a/tasm-lib/src/arithmetic/u32/safe_mul.rs
+++ b/tasm-lib/src/arithmetic/u32/safe_mul.rs
@@ -77,10 +77,13 @@ mod tests {
     impl Closure for SafeMul {
         type Args = (u32, u32);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (right, left) = pop_encodable::<Self::Args>(stack);
-            let product = left.checked_mul(right).unwrap();
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (right, left) = pop_encodable::<Self::Args>(stack)?;
+            let product = left
+                .checked_mul(right)
+                .ok_or(RustShadowError::ArithmeticOverflow)?;
             push_encodable(stack, &product);
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u32/safe_pow.rs
+++ b/tasm-lib/src/arithmetic/u32/safe_pow.rs
@@ -148,9 +148,13 @@ mod tests {
     impl Closure for SafePow {
         type Args = (u32, u32);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (base, exponent) = pop_encodable::<Self::Args>(stack);
-            push_encodable(stack, &(base.pow(exponent)));
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (base, exponent) = pop_encodable::<Self::Args>(stack)?;
+            let pow = base
+                .checked_pow(exponent)
+                .ok_or(RustShadowError::ArithmeticOverflow)?;
+            push_encodable(stack, &pow);
+            Ok(())
         }
 
         fn pseudorandom_args(
@@ -213,7 +217,7 @@ mod tests {
         ] {
             let initial_stack = SafePow.set_up_test_stack((base, exp));
             let mut expected_final_stack = initial_stack.clone();
-            SafePow.rust_shadow(&mut expected_final_stack);
+            SafePow.rust_shadow(&mut expected_final_stack).unwrap();
 
             let _vm_output_state = test_rust_equivalence_given_complete_state(
                 &ShadowedClosure::new(SafePow),

--- a/tasm-lib/src/arithmetic/u32/safe_pow.rs
+++ b/tasm-lib/src/arithmetic/u32/safe_pow.rs
@@ -176,12 +176,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn ruts_shadow() {
         ShadowedClosure::new(SafePow).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn u32_pow_unit_test() {
         for (base, exp) in [
             (0, 0),
@@ -226,7 +226,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn u32_pow_negative_test() {
         for (base, exp) in [
             (2, 32),
@@ -274,7 +274,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(SafePow).bench()
     }

--- a/tasm-lib/src/arithmetic/u32/safe_sub.rs
+++ b/tasm-lib/src/arithmetic/u32/safe_sub.rs
@@ -79,10 +79,13 @@ mod tests {
     impl Closure for SafeSub {
         type Args = (u32, u32);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (right, left) = pop_encodable::<Self::Args>(stack);
-            let diff = left.checked_sub(right).unwrap();
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (right, left) = pop_encodable::<Self::Args>(stack)?;
+            let diff = left
+                .checked_sub(right)
+                .ok_or(RustShadowError::ArithmeticOverflow)?;
             push_encodable(stack, &diff);
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u32/safe_sub.rs
+++ b/tasm-lib/src/arithmetic/u32/safe_sub.rs
@@ -109,12 +109,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(SafeSub).test();
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn overflow_crashes_vm(
         #[filter(#left != u32::MAX)] left: u32,
         #[strategy(#left..)] right: u32,
@@ -132,7 +132,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn safe_sub_benchmark() {
         ShadowedClosure::new(SafeSub).bench();
     }

--- a/tasm-lib/src/arithmetic/u32/shift_left.rs
+++ b/tasm-lib/src/arithmetic/u32/shift_left.rs
@@ -109,12 +109,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(ShiftLeft).test();
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn too_big_shift_amount_crashes_vm(arg: u32, #[strategy(32_u32..)] shift_amount: u32) {
         test_assertion_failure(
             &ShadowedClosure::new(ShiftLeft),
@@ -129,7 +129,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(ShiftLeft).bench();
     }

--- a/tasm-lib/src/arithmetic/u32/shift_left.rs
+++ b/tasm-lib/src/arithmetic/u32/shift_left.rs
@@ -85,10 +85,13 @@ mod tests {
     impl Closure for ShiftLeft {
         type Args = (u32, u32);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (arg, shift_amount) = pop_encodable::<Self::Args>(stack);
-            assert!(shift_amount < 32);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (arg, shift_amount) = pop_encodable::<Self::Args>(stack)?;
+            if shift_amount >= 32 {
+                return Err(RustShadowError::ArithmeticOverflow);
+            }
             push_encodable(stack, &(arg << shift_amount));
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u32/shift_right.rs
+++ b/tasm-lib/src/arithmetic/u32/shift_right.rs
@@ -119,12 +119,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(ShiftRight).test();
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn too_big_shift_amount_crashes_vm(arg: u32, #[strategy(32_u32..)] shift_amount: u32) {
         test_assertion_failure(
             &ShadowedClosure::new(ShiftRight),
@@ -139,7 +139,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(ShiftRight).bench();
     }

--- a/tasm-lib/src/arithmetic/u32/shift_right.rs
+++ b/tasm-lib/src/arithmetic/u32/shift_right.rs
@@ -95,10 +95,13 @@ mod tests {
     impl Closure for ShiftRight {
         type Args = (u32, u32);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (arg, shift_amount) = pop_encodable::<Self::Args>(stack);
-            assert!(shift_amount < 32);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (arg, shift_amount) = pop_encodable::<Self::Args>(stack)?;
+            if shift_amount >= 32 {
+                return Err(RustShadowError::ArithmeticOverflow);
+            }
             push_encodable(stack, &(arg >> shift_amount));
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u32/trailing_zeros.rs
+++ b/tasm-lib/src/arithmetic/u32/trailing_zeros.rs
@@ -119,9 +119,10 @@ mod tests {
     impl Closure for TrailingZeros {
         type Args = u32;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let arg = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let arg = pop_encodable::<Self::Args>(stack)?;
             push_encodable(stack, &arg.trailing_zeros());
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u32/trailing_zeros.rs
+++ b/tasm-lib/src/arithmetic/u32/trailing_zeros.rs
@@ -144,7 +144,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn unit() {
         ShadowedClosure::new(TrailingZeros).test();
     }
@@ -155,7 +155,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(TrailingZeros).bench()
     }

--- a/tasm-lib/src/arithmetic/u64/add.rs
+++ b/tasm-lib/src/arithmetic/u64/add.rs
@@ -79,10 +79,13 @@ mod tests {
     impl Closure for Add {
         type Args = <OverflowingAdd as Closure>::Args;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (left, right) = pop_encodable::<Self::Args>(stack);
-            let sum = left.checked_add(right).expect("overflow occurred");
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (left, right) = pop_encodable::<Self::Args>(stack)?;
+            let sum = left
+                .checked_add(right)
+                .ok_or(RustShadowError::ArithmeticOverflow)?;
             push_encodable(stack, &sum);
+            Ok(())
         }
 
         fn pseudorandom_args(&self, seed: [u8; 32], _: Option<BenchmarkCase>) -> Self::Args {

--- a/tasm-lib/src/arithmetic/u64/add.rs
+++ b/tasm-lib/src/arithmetic/u64/add.rs
@@ -105,18 +105,18 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn unit_test() {
         ShadowedClosure::new(Add).test();
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn proptest(left: u64, #[strategy(0..u64::MAX - #left)] right: u64) {
         let initial_state = InitVmState::with_stack(Add.set_up_test_stack((left, right)));
         test_rust_equivalence_given_execution_state(&ShadowedClosure::new(Add), initial_state);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn triton_vm_crashes_on_overflowing_add(left: u64, #[strategy(u64::MAX - #left..)] right: u64) {
         prop_assume!(left.checked_add(right).is_none());
 
@@ -133,7 +133,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(Add).bench()
     }

--- a/tasm-lib/src/arithmetic/u64/and.rs
+++ b/tasm-lib/src/arithmetic/u64/and.rs
@@ -103,7 +103,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(And).test();
     }
@@ -114,7 +114,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(And).bench();
     }

--- a/tasm-lib/src/arithmetic/u64/and.rs
+++ b/tasm-lib/src/arithmetic/u64/and.rs
@@ -77,9 +77,10 @@ pub(crate) mod tests {
     impl Closure for And {
         type Args = (u64, u64);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (right, left) = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (right, left) = pop_encodable::<Self::Args>(stack)?;
             push_encodable(stack, &(left & right));
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u64/decr.rs
+++ b/tasm-lib/src/arithmetic/u64/decr.rs
@@ -117,12 +117,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(Decr).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn negative_test() {
         test_assertion_failure(
             &ShadowedClosure::new(Decr),
@@ -137,7 +137,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(Decr).bench();
     }

--- a/tasm-lib/src/arithmetic/u64/decr.rs
+++ b/tasm-lib/src/arithmetic/u64/decr.rs
@@ -99,9 +99,13 @@ mod tests {
     impl Closure for Decr {
         type Args = u64;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let arg = pop_encodable::<Self::Args>(stack);
-            push_encodable(stack, &arg.checked_sub(1).unwrap());
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let arg = pop_encodable::<Self::Args>(stack)?;
+            let decremented = arg
+                .checked_sub(1)
+                .ok_or(RustShadowError::ArithmeticOverflow)?;
+            push_encodable(stack, &decremented);
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u64/div2.rs
+++ b/tasm-lib/src/arithmetic/u64/div2.rs
@@ -123,12 +123,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(Div2).test();
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn lo_is_not_u32(hi: u32, #[strategy(1_u64 << 32..)] lo: u64) {
         let stack = [Div2.init_stack_for_isolated_run(), bfe_vec![hi, lo]].concat();
 
@@ -140,7 +140,7 @@ mod tests {
         );
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn hi_is_not_u32(#[strategy(1_u64 << 32..)] hi: u64, lo: u32) {
         let stack = [Div2.init_stack_for_isolated_run(), bfe_vec![hi, lo]].concat();
 
@@ -152,7 +152,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn div_2_test() {
         let small_args = 0..9;
         let mid_args = (0..9).map(|offset| (1 << 32) + offset);
@@ -169,7 +169,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(Div2).bench();
     }

--- a/tasm-lib/src/arithmetic/u64/div2.rs
+++ b/tasm-lib/src/arithmetic/u64/div2.rs
@@ -89,7 +89,7 @@ mod tests {
             let initial_stack = self.set_up_test_stack(arg);
 
             let mut expected_stack = initial_stack.clone();
-            self.rust_shadow(&mut expected_stack);
+            self.rust_shadow(&mut expected_stack).unwrap();
 
             test_rust_equivalence_given_complete_state(
                 &ShadowedClosure::new(Self),
@@ -105,9 +105,10 @@ mod tests {
     impl Closure for Div2 {
         type Args = u64;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let arg = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let arg = pop_encodable::<Self::Args>(stack)?;
             push_encodable(stack, &(arg / 2));
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u64/div_mod.rs
+++ b/tasm-lib/src/arithmetic/u64/div_mod.rs
@@ -433,9 +433,13 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let denominator = pop_encodable::<u64>(stack);
-            let numerator = pop_encodable::<u64>(stack);
+        ) -> Result<(), RustShadowError> {
+            let denominator = pop_encodable::<u64>(stack)?;
+            let numerator = pop_encodable::<u64>(stack)?;
+            if denominator == 0 {
+                return Err(RustShadowError::Other);
+            }
+
             let quotient = numerator / denominator;
             let remainder = numerator % denominator;
             push_encodable(stack, &quotient);
@@ -444,6 +448,7 @@ mod tests {
             // Accomodate spilling. This could probably be avoided if the code was compiled
             // by hand instead.
             encode_to_memory(memory, STATIC_MEMORY_FIRST_ADDRESS - bfe!(1), &denominator);
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/arithmetic/u64/div_mod.rs
+++ b/tasm-lib/src/arithmetic/u64/div_mod.rs
@@ -525,12 +525,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedFunction::new(DivMod).test();
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn fail_vm_execution_on_divide_by_zero_u32_numerator(numerator: u64) {
         test_assertion_failure(
             &ShadowedFunction::new(DivMod),
@@ -545,7 +545,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(DivMod).bench();
     }

--- a/tasm-lib/src/arithmetic/u64/incr.rs
+++ b/tasm-lib/src/arithmetic/u64/incr.rs
@@ -111,12 +111,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(Incr).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn u64_max_crashes_vm() {
         test_assertion_failure(
             &ShadowedClosure::new(Incr),
@@ -131,7 +131,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(Incr).bench();
     }

--- a/tasm-lib/src/arithmetic/u64/incr.rs
+++ b/tasm-lib/src/arithmetic/u64/incr.rs
@@ -88,10 +88,13 @@ mod tests {
     impl Closure for Incr {
         type Args = u64;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let v = pop_encodable::<Self::Args>(stack);
-            let incr = v.checked_add(1).unwrap();
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let v = pop_encodable::<Self::Args>(stack)?;
+            let incr = v
+                .checked_add(1)
+                .ok_or(RustShadowError::ArithmeticOverflow)?;
             push_encodable(stack, &incr);
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u64/leading_zeros.rs
+++ b/tasm-lib/src/arithmetic/u64/leading_zeros.rs
@@ -67,9 +67,10 @@ mod tests {
     impl Closure for LeadingZeros {
         type Args = u64;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let arg = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let arg = pop_encodable::<Self::Args>(stack)?;
             push_encodable(stack, &arg.leading_zeros());
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u64/leading_zeros.rs
+++ b/tasm-lib/src/arithmetic/u64/leading_zeros.rs
@@ -93,7 +93,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn unit() {
         ShadowedClosure::new(LeadingZeros).test();
     }
@@ -104,7 +104,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(LeadingZeros).bench();
     }

--- a/tasm-lib/src/arithmetic/u64/log_2_floor.rs
+++ b/tasm-lib/src/arithmetic/u64/log_2_floor.rs
@@ -135,12 +135,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow_test() {
         ShadowedClosure::new(Log2Floor).test();
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn hi_is_u32_but_lo_is_not(
         #[strategy(0_u32..)]
         #[map(BFieldElement::from)]
@@ -161,7 +161,7 @@ mod tests {
         );
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn hi_is_not_u32_but_lo_is(
         #[strategy(1_u64 << 32..)]
         #[map(BFieldElement::new)]
@@ -182,7 +182,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn crash_on_zero() {
         negative_test(
             &ShadowedClosure::new(Log2Floor),
@@ -191,7 +191,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn unit_test() {
         fn assert_terminal_stack_is_as_expected(x: u64, expected: u32) {
             let mut expected_stack = Log2Floor.init_stack_for_isolated_run();
@@ -227,7 +227,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(Log2Floor).bench();
     }

--- a/tasm-lib/src/arithmetic/u64/log_2_floor.rs
+++ b/tasm-lib/src/arithmetic/u64/log_2_floor.rs
@@ -108,9 +108,11 @@ mod tests {
     impl Closure for Log2Floor {
         type Args = u64;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let x = pop_encodable::<Self::Args>(stack);
-            push_encodable(stack, &x.ilog2());
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let x = pop_encodable::<Self::Args>(stack)?;
+            let log = x.checked_ilog2().ok_or(RustShadowError::Other)?;
+            push_encodable(stack, &log);
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u64/lt.rs
+++ b/tasm-lib/src/arithmetic/u64/lt.rs
@@ -144,17 +144,17 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow_test() {
         ShadowedClosure::new(Lt).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn unit_test() {
         Lt.assert_expected_lt_behavior(11 * (1 << 32), 15 * (1 << 32));
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn property_test(left: u64, right: u64) {
         Lt.assert_expected_lt_behavior(left, right);
     }
@@ -165,7 +165,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(Lt).bench();
     }

--- a/tasm-lib/src/arithmetic/u64/lt.rs
+++ b/tasm-lib/src/arithmetic/u64/lt.rs
@@ -96,7 +96,7 @@ pub(crate) mod tests {
             let initial_stack = self.set_up_test_stack((lhs, rhs));
 
             let mut expected_stack = initial_stack.clone();
-            self.rust_shadow(&mut expected_stack);
+            self.rust_shadow(&mut expected_stack).unwrap();
 
             test_rust_equivalence_given_complete_state(
                 &ShadowedClosure::new(Self),
@@ -112,9 +112,10 @@ pub(crate) mod tests {
     impl Closure for Lt {
         type Args = (u64, u64);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (right, left) = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (right, left) = pop_encodable::<Self::Args>(stack)?;
             push_encodable(stack, &(left < right));
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u64/lt_preserve_args.rs
+++ b/tasm-lib/src/arithmetic/u64/lt_preserve_args.rs
@@ -135,17 +135,17 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow_test() {
         ShadowedClosure::new(LtPreserveArgs).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn unit_test() {
         LtPreserveArgs.assert_expected_lt_behavior(11 * (1 << 32), 15 * (1 << 32));
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn property_test(left: u64, right: u64) {
         LtPreserveArgs.assert_expected_lt_behavior(left, right);
     }
@@ -156,7 +156,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(LtPreserveArgs).bench();
     }

--- a/tasm-lib/src/arithmetic/u64/lt_preserve_args.rs
+++ b/tasm-lib/src/arithmetic/u64/lt_preserve_args.rs
@@ -100,7 +100,7 @@ mod tests {
             let initial_stack = self.set_up_test_stack((left, right));
 
             let mut expected_stack = initial_stack.clone();
-            self.rust_shadow(&mut expected_stack);
+            self.rust_shadow(&mut expected_stack).unwrap();
 
             test_rust_equivalence_given_complete_state(
                 &ShadowedClosure::new(Self),
@@ -116,10 +116,11 @@ mod tests {
     impl Closure for LtPreserveArgs {
         type Args = <Lt as Closure>::Args;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (right, left) = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (right, left) = pop_encodable::<Self::Args>(stack)?;
             push_encodable(stack, &(right, left));
             push_encodable(stack, &(left < right));
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u64/mul_two_u64s_to_u128.rs
+++ b/tasm-lib/src/arithmetic/u64/mul_two_u64s_to_u128.rs
@@ -103,10 +103,11 @@ mod tests {
     impl Closure for MulTwoU64sToU128 {
         type Args = (u64, u64);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (right, left) = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (right, left) = pop_encodable::<Self::Args>(stack)?;
             let product = u128::from(left) * u128::from(right);
             push_encodable(stack, &product);
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u64/mul_two_u64s_to_u128.rs
+++ b/tasm-lib/src/arithmetic/u64/mul_two_u64s_to_u128.rs
@@ -126,7 +126,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(MulTwoU64sToU128).test();
     }
@@ -137,7 +137,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(MulTwoU64sToU128).bench();
     }

--- a/tasm-lib/src/arithmetic/u64/or.rs
+++ b/tasm-lib/src/arithmetic/u64/or.rs
@@ -83,10 +83,11 @@ mod tests {
     impl Closure for Or {
         type Args = (u64, u64);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (right, left) = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (right, left) = pop_encodable::<Self::Args>(stack)?;
             let or = left | right;
             push_encodable(stack, &or);
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u64/or.rs
+++ b/tasm-lib/src/arithmetic/u64/or.rs
@@ -106,7 +106,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(Or).test();
     }
@@ -117,7 +117,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(Or).bench();
     }

--- a/tasm-lib/src/arithmetic/u64/overflowing_add.rs
+++ b/tasm-lib/src/arithmetic/u64/overflowing_add.rs
@@ -106,12 +106,13 @@ pub mod tests {
     impl Closure for OverflowingAdd {
         type Args = (u64, u64);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let right = pop_encodable::<u64>(stack);
-            let left = pop_encodable::<u64>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let right = pop_encodable::<u64>(stack)?;
+            let left = pop_encodable::<u64>(stack)?;
             let (sum, is_overflow) = left.overflowing_add(right);
             push_encodable(stack, &sum);
             push_encodable(stack, &is_overflow);
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u64/overflowing_add.rs
+++ b/tasm-lib/src/arithmetic/u64/overflowing_add.rs
@@ -137,7 +137,7 @@ pub mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn u64_overflowing_add_pbt() {
         ShadowedClosure::new(OverflowingAdd).test()
     }
@@ -148,7 +148,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(OverflowingAdd).bench()
     }

--- a/tasm-lib/src/arithmetic/u64/overflowing_sub.rs
+++ b/tasm-lib/src/arithmetic/u64/overflowing_sub.rs
@@ -187,7 +187,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(OverflowingSub).test()
     }
@@ -198,7 +198,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(OverflowingSub).bench()
     }

--- a/tasm-lib/src/arithmetic/u64/overflowing_sub.rs
+++ b/tasm-lib/src/arithmetic/u64/overflowing_sub.rs
@@ -159,9 +159,10 @@ pub(crate) mod tests {
     impl Closure for OverflowingSub {
         type Args = (u64, u64);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (subtrahend, minuend) = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (subtrahend, minuend) = pop_encodable::<Self::Args>(stack)?;
             push_encodable(stack, &minuend.overflowing_sub(subtrahend));
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u64/popcount.rs
+++ b/tasm-lib/src/arithmetic/u64/popcount.rs
@@ -67,9 +67,10 @@ mod tests {
     impl Closure for PopCount {
         type Args = u64;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let x = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let x = pop_encodable::<Self::Args>(stack)?;
             push_encodable(stack, &x.count_ones());
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u64/popcount.rs
+++ b/tasm-lib/src/arithmetic/u64/popcount.rs
@@ -93,7 +93,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow_test() {
         ShadowedClosure::new(PopCount).test()
     }
@@ -104,7 +104,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(PopCount).bench();
     }

--- a/tasm-lib/src/arithmetic/u64/pow2.rs
+++ b/tasm-lib/src/arithmetic/u64/pow2.rs
@@ -111,19 +111,19 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(Pow2).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn unit_test() {
         for arg in 0..64 {
             Pow2.assert_expected_behavior(arg);
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn negative_property_test(#[strategy(64_u32..)] arg: u32) {
         let stack = Pow2.set_up_test_stack(arg);
 
@@ -140,7 +140,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(Pow2).bench();
     }

--- a/tasm-lib/src/arithmetic/u64/pow2.rs
+++ b/tasm-lib/src/arithmetic/u64/pow2.rs
@@ -74,7 +74,7 @@ mod tests {
             let initial_stack = self.set_up_test_stack(arg);
 
             let mut expected_stack = initial_stack.clone();
-            self.rust_shadow(&mut expected_stack);
+            self.rust_shadow(&mut expected_stack).unwrap();
 
             test_rust_equivalence_given_complete_state(
                 &ShadowedClosure::new(Self),
@@ -90,9 +90,13 @@ mod tests {
     impl Closure for Pow2 {
         type Args = u32;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let arg = pop_encodable::<Self::Args>(stack);
-            push_encodable(stack, &2_u64.pow(arg));
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let arg = pop_encodable::<Self::Args>(stack)?;
+            let pow = 2_u64
+                .checked_pow(arg)
+                .ok_or(RustShadowError::ArithmeticOverflow)?;
+            push_encodable(stack, &pow);
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u64/safe_mul.rs
+++ b/tasm-lib/src/arithmetic/u64/safe_mul.rs
@@ -133,11 +133,14 @@ mod tests {
     impl Closure for SafeMul {
         type Args = (u64, u64);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (right, left) = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (right, left) = pop_encodable::<Self::Args>(stack)?;
             let (product, is_overflow) = left.overflowing_mul(right);
-            assert!(!is_overflow);
+            if is_overflow {
+                return Err(RustShadowError::ArithmeticOverflow);
+            }
             push_encodable(stack, &product);
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u64/safe_mul.rs
+++ b/tasm-lib/src/arithmetic/u64/safe_mul.rs
@@ -157,12 +157,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(SafeMul).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn overflow_tests() {
         let failure_conditions = [
             (1 << 32, 1 << 32, 100),             // (left_hi · right_hi) != 0
@@ -185,7 +185,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(SafeMul).bench();
     }

--- a/tasm-lib/src/arithmetic/u64/shift_left.rs
+++ b/tasm-lib/src/arithmetic/u64/shift_left.rs
@@ -132,7 +132,7 @@ pub(crate) mod tests {
             let initial_stack = self.set_up_test_stack((arg, shift_amount));
 
             let mut expected_stack = initial_stack.clone();
-            self.rust_shadow(&mut expected_stack);
+            self.rust_shadow(&mut expected_stack).unwrap();
 
             test_rust_equivalence_given_complete_state(
                 &ShadowedClosure::new(Self),
@@ -148,10 +148,13 @@ pub(crate) mod tests {
     impl Closure for ShiftLeft {
         type Args = (u64, u32);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (arg, shift_amount) = pop_encodable::<Self::Args>(stack);
-            assert!(shift_amount < 64);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (arg, shift_amount) = pop_encodable::<Self::Args>(stack)?;
+            if shift_amount >= 64 {
+                return Err(RustShadowError::ArithmeticOverflow);
+            }
             push_encodable(stack, &(arg << shift_amount));
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u64/shift_left.rs
+++ b/tasm-lib/src/arithmetic/u64/shift_left.rs
@@ -173,24 +173,24 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(ShiftLeft).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn edge_cases() {
         for i in 0..64 {
             ShiftLeft.assert_expected_behavior(i, u64::MAX);
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn property_test(arg: u64, #[strategy(0_u32..64)] shift_amount: u32) {
         ShiftLeft.assert_expected_behavior(shift_amount, arg);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn negative_property_test(arg: u64, #[strategy(64_u32..)] shift_amount: u32) {
         test_assertion_failure(
             &ShadowedClosure::new(ShiftLeft),
@@ -205,7 +205,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(ShiftLeft).bench();
     }

--- a/tasm-lib/src/arithmetic/u64/shift_right.rs
+++ b/tasm-lib/src/arithmetic/u64/shift_right.rs
@@ -194,22 +194,22 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(ShiftRight).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn unit_test() {
         ShiftRight.assert_expected_shift_right_behavior(2, 8);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn property_test(arg: u64, #[strategy(0_u32..64)] shift_amount: u32) {
         ShiftRight.assert_expected_shift_right_behavior(shift_amount, arg);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn negative_property_test(arg: u64, #[strategy(64_u32..)] shift_amount: u32) {
         test_assertion_failure(
             &ShadowedClosure::new(ShiftRight),
@@ -224,7 +224,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(ShiftRight).bench();
     }

--- a/tasm-lib/src/arithmetic/u64/shift_right.rs
+++ b/tasm-lib/src/arithmetic/u64/shift_right.rs
@@ -153,7 +153,7 @@ mod tests {
             let initial_stack = self.set_up_test_stack((arg, shift_amount));
 
             let mut expected_stack = initial_stack.clone();
-            self.rust_shadow(&mut expected_stack);
+            self.rust_shadow(&mut expected_stack).unwrap();
 
             test_rust_equivalence_given_complete_state(
                 &ShadowedClosure::new(Self),
@@ -169,10 +169,13 @@ mod tests {
     impl Closure for ShiftRight {
         type Args = (u64, u32);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (arg, shift_amount) = pop_encodable::<Self::Args>(stack);
-            assert!(shift_amount < 64);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (arg, shift_amount) = pop_encodable::<Self::Args>(stack)?;
+            if shift_amount >= 64 {
+                return Err(RustShadowError::ArithmeticOverflow);
+            }
             push_encodable(stack, &(arg >> shift_amount));
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u64/sub.rs
+++ b/tasm-lib/src/arithmetic/u64/sub.rs
@@ -134,23 +134,23 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(Sub).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn unit_test() {
         Sub.assert_expected_behavior(129, 256);
         Sub.assert_expected_behavior(1, 1 << 32);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn property_test(subtrahend: u64, #[strategy(#subtrahend..)] minuend: u64) {
         Sub.assert_expected_behavior(subtrahend, minuend);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn negative_property_test(
         #[strategy(1_u64..)] subtrahend: u64,
         #[strategy(..#subtrahend)] minuend: u64,
@@ -168,7 +168,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(Sub).bench();
     }

--- a/tasm-lib/src/arithmetic/u64/sub.rs
+++ b/tasm-lib/src/arithmetic/u64/sub.rs
@@ -83,7 +83,7 @@ mod tests {
     impl Sub {
         pub fn assert_expected_behavior(&self, subtrahend: u64, minuend: u64) {
             let mut expected_stack = self.set_up_test_stack((subtrahend, minuend));
-            self.rust_shadow(&mut expected_stack);
+            self.rust_shadow(&mut expected_stack).unwrap();
 
             test_rust_equivalence_given_complete_state(
                 &ShadowedClosure::new(Self),
@@ -99,9 +99,13 @@ mod tests {
     impl Closure for Sub {
         type Args = <OverflowingSub as Closure>::Args;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (subtrahend, minuend) = pop_encodable::<Self::Args>(stack);
-            push_encodable(stack, &(minuend - subtrahend));
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (subtrahend, minuend) = pop_encodable::<Self::Args>(stack)?;
+            let difference = minuend
+                .checked_sub(subtrahend)
+                .ok_or(RustShadowError::ArithmeticOverflow)?;
+            push_encodable(stack, &difference);
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u64/trailing_zeros.rs
+++ b/tasm-lib/src/arithmetic/u64/trailing_zeros.rs
@@ -100,9 +100,10 @@ mod tests {
     impl Closure for TrailingZeros {
         type Args = u64;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let arg = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let arg = pop_encodable::<Self::Args>(stack)?;
             push_encodable(stack, &arg.trailing_zeros());
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u64/trailing_zeros.rs
+++ b/tasm-lib/src/arithmetic/u64/trailing_zeros.rs
@@ -125,7 +125,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn unit() {
         ShadowedClosure::new(TrailingZeros).test();
     }
@@ -136,7 +136,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(TrailingZeros).bench()
     }

--- a/tasm-lib/src/arithmetic/u64/wrapping_mul.rs
+++ b/tasm-lib/src/arithmetic/u64/wrapping_mul.rs
@@ -112,7 +112,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(WrappingMul).test();
     }
@@ -123,7 +123,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(WrappingMul).bench();
     }

--- a/tasm-lib/src/arithmetic/u64/wrapping_mul.rs
+++ b/tasm-lib/src/arithmetic/u64/wrapping_mul.rs
@@ -94,9 +94,10 @@ mod tests {
     impl Closure for WrappingMul {
         type Args = (u64, u64);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (right, left) = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (right, left) = pop_encodable::<Self::Args>(stack)?;
             push_encodable(stack, &left.wrapping_mul(right));
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u64/wrapping_sub.rs
+++ b/tasm-lib/src/arithmetic/u64/wrapping_sub.rs
@@ -96,7 +96,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(WrappingSub).test()
     }
@@ -107,7 +107,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(WrappingSub).bench()
     }

--- a/tasm-lib/src/arithmetic/u64/wrapping_sub.rs
+++ b/tasm-lib/src/arithmetic/u64/wrapping_sub.rs
@@ -76,11 +76,12 @@ mod tests {
     impl Closure for WrappingSub {
         type Args = <OverflowingSub as Closure>::Args;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let minuend = pop_encodable::<u64>(stack);
-            let subtrahend = pop_encodable::<u64>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let minuend = pop_encodable::<u64>(stack)?;
+            let subtrahend = pop_encodable::<u64>(stack)?;
             let difference = minuend.wrapping_sub(subtrahend);
             push_encodable(stack, &difference);
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/u64/xor.rs
+++ b/tasm-lib/src/arithmetic/u64/xor.rs
@@ -94,7 +94,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(Xor).test();
     }
@@ -105,7 +105,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(Xor).bench();
     }

--- a/tasm-lib/src/arithmetic/u64/xor.rs
+++ b/tasm-lib/src/arithmetic/u64/xor.rs
@@ -76,9 +76,10 @@ mod tests {
     impl Closure for Xor {
         type Args = (u64, u64);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (right, left) = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (right, left) = pop_encodable::<Self::Args>(stack)?;
             push_encodable(stack, &(left ^ right));
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/xfe/mod_pow_u32.rs
+++ b/tasm-lib/src/arithmetic/xfe/mod_pow_u32.rs
@@ -183,12 +183,12 @@ pub mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn mod_pow_u32_xfe_pbt() {
         ShadowedClosure::new(XfeModPowU32).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn verify_crash_if_exponent_not_u32() {
         let bfe_14 = BFieldElement::new(14);
         let xfe_14 = XFieldElement::new([bfe_14, bfe_14, bfe_14]);
@@ -224,7 +224,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(XfeModPowU32).bench();
     }

--- a/tasm-lib/src/arithmetic/xfe/mod_pow_u32.rs
+++ b/tasm-lib/src/arithmetic/xfe/mod_pow_u32.rs
@@ -152,10 +152,11 @@ pub mod tests {
     impl Closure for XfeModPowU32 {
         type Args = (u32, XFieldElement);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (exponent, base) = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (exponent, base) = pop_encodable::<Self::Args>(stack)?;
             let result = base.mod_pow_u32(exponent);
             push_encodable(stack, &result);
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/arithmetic/xfe/to_the_power_of_power_of_2.rs
+++ b/tasm-lib/src/arithmetic/xfe/to_the_power_of_power_of_2.rs
@@ -128,12 +128,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(ToThePowerOfPowerOf2).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn compare_to_generic_pow_u32() {
         let base = rand::random();
         for log_2_exponent in 0..32 {
@@ -172,7 +172,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(ToThePowerOfPowerOf2).bench();
     }

--- a/tasm-lib/src/arithmetic/xfe/to_the_power_of_power_of_2.rs
+++ b/tasm-lib/src/arithmetic/xfe/to_the_power_of_power_of_2.rs
@@ -99,10 +99,11 @@ mod tests {
     impl Closure for ToThePowerOfPowerOf2 {
         type Args = (u32, XFieldElement);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (exponent_log_2, base) = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (exponent_log_2, base) = pop_encodable::<Self::Args>(stack)?;
             let result = base.mod_pow_u32(2_u32.pow(exponent_log_2));
             push_encodable(stack, &result);
+            Ok(())
         }
 
         fn pseudorandom_args(
@@ -130,7 +131,7 @@ mod tests {
 
     #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
-        ShadowedClosure::new(ToThePowerOfPowerOf2).test()
+        ShadowedClosure::new(ToThePowerOfPowerOf2).test();
     }
 
     #[macro_rules_attr::apply(test)]

--- a/tasm-lib/src/array/horner_evaluation.rs
+++ b/tasm-lib/src/array/horner_evaluation.rs
@@ -117,18 +117,23 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let indeterminate = pop_encodable(stack);
-            let coefficient_ptr = stack.pop().unwrap();
+        ) -> Result<(), RustShadowError> {
+            let indeterminate = pop_encodable(stack)?;
+            let coefficient_ptr = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
 
-            let coefficients = (0..self.num_coefficients)
+            let coefficients: Vec<XFieldElement> = (0..self.num_coefficients)
                 .map(|i| array_get(coefficient_ptr, i, memory, 3))
-                .map(|bfes| XFieldElement::new(bfes.try_into().unwrap()))
-                .collect();
+                .map(|bfes| {
+                    bfes.try_into()
+                        .map(XFieldElement::new)
+                        .map_err(|_| RustShadowError::Other)
+                })
+                .try_collect()?;
             let polynomial = Polynomial::new(coefficients);
             let evaluation = polynomial.evaluate_in_same_field(indeterminate);
 
             push_encodable(stack, &evaluation);
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/array/horner_evaluation.rs
+++ b/tasm-lib/src/array/horner_evaluation.rs
@@ -154,7 +154,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         for n in [0, 1, 4, 20, 587, 1000] {
             ShadowedAccessor::new(HornerEvaluation::new(n)).test();
@@ -167,7 +167,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench() {
         for n in [100, 587] {
             ShadowedAccessor::new(HornerEvaluation::new(n)).bench();

--- a/tasm-lib/src/array/inner_product_of_three_rows_with_weights.rs
+++ b/tasm-lib/src/array/inner_product_of_three_rows_with_weights.rs
@@ -169,21 +169,21 @@ mod tests {
     use crate::rust_shadowing_helper_functions::array::insert_random_array;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn three_rows_tvm_parameters_xfe_main_test() {
         let snippet =
             InnerProductOfThreeRowsWithWeights::triton_vm_parameters(MainElementType::Xfe);
         ShadowedAccessor::new(snippet).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn three_rows_tvm_parameters_bfe_main_test() {
         let snippet =
             InnerProductOfThreeRowsWithWeights::triton_vm_parameters(MainElementType::Bfe);
         ShadowedAccessor::new(snippet).test();
     }
 
-    #[proptest(cases = 10)]
+    #[macro_rules_attr::apply(proptest(cases = 10))]
     fn main_or_aux_column_count_can_be_zero(#[strategy(0_usize..500)] len: usize) {
         for elt_ty in [MainElementType::Bfe, MainElementType::Xfe] {
             ShadowedAccessor::new(InnerProductOfThreeRowsWithWeights::new(0, elt_ty, len)).test();
@@ -191,7 +191,7 @@ mod tests {
         }
     }
 
-    #[proptest(cases = 6)]
+    #[macro_rules_attr::apply(proptest(cases = 6))]
     fn three_rows_pbt_pbt(
         #[strategy(arb())] main_element_type: MainElementType,
         #[strategy(0_usize..500)] main_length: usize,
@@ -279,7 +279,7 @@ mod benches {
 
     /// Benchmark the calculation of the (in-domain) current rows that happen in the
     /// main-loop, where all revealed FRI values are verified.
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_current_tvm_bfe() {
         let snippet =
             InnerProductOfThreeRowsWithWeights::triton_vm_parameters(MainElementType::Bfe);
@@ -287,7 +287,7 @@ mod benches {
     }
 
     /// Benchmark the calculation of the out-of-domain current and next row values.
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_current_tvm_xfe() {
         let snippet =
             InnerProductOfThreeRowsWithWeights::triton_vm_parameters(MainElementType::Xfe);

--- a/tasm-lib/src/array/inner_product_of_three_rows_with_weights.rs
+++ b/tasm-lib/src/array/inner_product_of_three_rows_with_weights.rs
@@ -207,10 +207,10 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let weights_address = stack.pop().unwrap();
-            let main_row_address = stack.pop().unwrap();
-            let aux_row_address = stack.pop().unwrap();
+        ) -> Result<(), RustShadowError> {
+            let weights_address = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let main_row_address = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let aux_row_address = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
 
             let weights_len = self.main_length + self.aux_length;
             let weights = array_from_memory::<XFieldElement>(weights_address, weights_len, memory);
@@ -235,8 +235,9 @@ mod tests {
                 .zip_eq(weights)
                 .map(|(element, weight)| element * weight)
                 .sum::<XFieldElement>();
+            push_encodable(stack, &inner_product);
 
-            push_encodable(stack, &inner_product)
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/array/inner_product_of_xfes.rs
+++ b/tasm-lib/src/array/inner_product_of_xfes.rs
@@ -143,14 +143,14 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn inner_product_of_xfes_pbt() {
         for test_case in (0..20).chain(100..110).map(InnerProductOfXfes::new) {
             ShadowedAccessor::new(test_case).test()
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn inner_product_unit_test() {
         let a = xfe_vec![[3, 0, 0], [5, 0, 0]];
         let b = xfe_vec![[501, 0, 0], [1003, 0, 0]];
@@ -196,7 +196,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedAccessor::new(InnerProductOfXfes::new(100)).bench();
         ShadowedAccessor::new(InnerProductOfXfes::new(200)).bench();

--- a/tasm-lib/src/array/inner_product_of_xfes.rs
+++ b/tasm-lib/src/array/inner_product_of_xfes.rs
@@ -104,12 +104,21 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let b = array_from_memory::<XFieldElement>(stack.pop().unwrap(), self.length, memory);
-            let a = array_from_memory::<XFieldElement>(stack.pop().unwrap(), self.length, memory);
+        ) -> Result<(), RustShadowError> {
+            let b = array_from_memory::<XFieldElement>(
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
+                self.length,
+                memory,
+            );
+            let a = array_from_memory::<XFieldElement>(
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
+                self.length,
+                memory,
+            );
             let inner_product: XFieldElement = a.into_iter().zip(b).map(|(a, b)| a * b).sum();
 
             push_encodable(stack, &inner_product);
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/array/sum_of_bfes.rs
+++ b/tasm-lib/src/array/sum_of_bfes.rs
@@ -124,7 +124,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn sum_bfes_pbt() {
         let snippets = (0..20).chain(100..110).map(|x| SumOfBfes { length: x });
         for test_case in snippets {
@@ -138,12 +138,12 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn sum_bfes_bench_100() {
         ShadowedFunction::new(SumOfBfes { length: 100 }).bench();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn sum_bfes_bench_200() {
         ShadowedFunction::new(SumOfBfes { length: 200 }).bench();
     }

--- a/tasm-lib/src/array/sum_of_bfes.rs
+++ b/tasm-lib/src/array/sum_of_bfes.rs
@@ -74,8 +74,8 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let mut array_pointer = stack.pop().unwrap();
+        ) -> Result<(), RustShadowError> {
+            let mut array_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
             let mut array_quote_unquote = bfe_vec![0; self.length];
             for array_elem in array_quote_unquote.iter_mut() {
                 memory
@@ -88,6 +88,7 @@ mod tests {
             let sum = array_quote_unquote.into_iter().sum();
 
             stack.push(sum);
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/array/sum_of_xfes.rs
+++ b/tasm-lib/src/array/sum_of_xfes.rs
@@ -165,7 +165,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn sum_xfes_pbt() {
         let snippets = (0..20).chain(100..110).map(|x| SumOfXfes { length: x });
         for test_case in snippets {
@@ -173,7 +173,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn xfe_array_sum_unit_test() {
         let xfes = vec![
             XFieldElement::new([
@@ -222,12 +222,12 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn sum_xfes_bench_100() {
         ShadowedFunction::new(SumOfXfes { length: 100 }).bench();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn sum_xfes_bench_200() {
         ShadowedFunction::new(SumOfXfes { length: 200 }).bench();
     }

--- a/tasm-lib/src/array/sum_of_xfes.rs
+++ b/tasm-lib/src/array/sum_of_xfes.rs
@@ -94,8 +94,8 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let mut array_pointer = stack.pop().unwrap();
+        ) -> Result<(), RustShadowError> {
+            let mut array_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
             let mut array_quote_unquote = vec![XFieldElement::zero(); self.length];
             for array_elem in array_quote_unquote.iter_mut() {
                 for word in array_elem.coefficients.iter_mut() {
@@ -112,6 +112,7 @@ mod tests {
             for word in sum.coefficients.into_iter().rev() {
                 stack.push(word);
             }
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/data_type.rs
+++ b/tasm-lib/src/data_type.rs
@@ -478,7 +478,7 @@ mod tests {
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn push_to_stack_leaves_value_on_top_of_stack(#[strategy(arb())] literal: Literal) {
         let code = triton_asm!(
             {&literal.push_to_stack_code()}
@@ -495,7 +495,7 @@ mod tests {
         assert_eq!(literal, read);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn static_lengths_match_up_for_vectors() {
         assert_eq!(
             <Vec<XFieldElement>>::static_length(),
@@ -503,7 +503,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn static_lengths_match_up_for_array_with_static_length_data_type() {
         assert_eq!(
             <[BFieldElement; 42]>::static_length(),
@@ -515,7 +515,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn static_lengths_match_up_for_array_with_dynamic_length_data_type() {
         assert_eq!(
             <[Vec<BFieldElement>; 42]>::static_length(),
@@ -527,7 +527,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn static_lengths_match_up_for_tuple_with_only_static_length_types() {
         assert_eq!(
             <(XFieldElement, BFieldElement)>::static_length(),
@@ -535,7 +535,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn static_lengths_match_up_for_tuple_with_dynamic_length_types() {
         assert_eq!(
             <(XFieldElement, Vec<BFieldElement>)>::static_length(),
@@ -544,12 +544,12 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn static_length_of_void_pointer_is_unknown() {
         assert!(DataType::VoidPointer.static_length().is_none());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn static_lengths_match_up_for_struct_with_only_static_length_types() {
         #[derive(Debug, Clone, BFieldCodec)]
         struct StructTyStatic {
@@ -570,7 +570,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn static_lengths_match_up_for_struct_with_dynamic_length_types() {
         #[derive(Debug, Clone, BFieldCodec)]
         struct StructTyDyn {
@@ -591,20 +591,20 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn random_list_of_lists_can_be_generated() {
         let mut rng = StdRng::seed_from_u64(5950175350772851878);
         let element_type = DataType::List(Box::new(DataType::Digest));
         let _list = element_type.random_list(&mut rng, 10);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn i128_sizes() {
         assert_eq!(4, DataType::I128.stack_size());
         assert_eq!(Some(4), DataType::I128.static_length());
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn non_negative_i128s_encode_like_u128s_prop(
         #[strategy(arb())]
         #[filter(#as_i128 >= 0i128)]
@@ -617,7 +617,7 @@ mod tests {
         );
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn i128_literals_prop(val: i128) {
         let program = Literal::I128(val).push_to_stack_code();
         let program = triton_program!(
@@ -632,7 +632,7 @@ mod tests {
         assert_eq!(val, popped);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn random_list_conforms_to_bfield_codec(#[strategy(..255_usize)] len: usize, seed: u64) {
         let mut rng = StdRng::seed_from_u64(seed);
         let element_type = DataType::Digest;
@@ -640,7 +640,7 @@ mod tests {
         prop_assert!(<Vec<Digest>>::decode(&list).is_ok());
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn random_list_of_lists_conforms_to_bfield_codec(
         #[strategy(..255_usize)] len: usize,
         seed: u64,
@@ -651,7 +651,7 @@ mod tests {
         prop_assert!(<Vec<Vec<Digest>>>::decode(&list).is_ok());
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn random_array_conforms_to_bfield_codec(seed: u64) {
         const LEN: usize = 42;
 
@@ -664,7 +664,7 @@ mod tests {
         prop_assert!(<[Digest; LEN]>::decode(&array).is_ok());
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn random_array_of_arrays_conforms_to_bfield_codec(seed: u64) {
         const INNER_LEN: usize = 42;
         const OUTER_LEN: usize = 13;
@@ -748,13 +748,13 @@ mod compare_literals {
     // stack size > 1
     comparison_snippet!(CompareDigests for tasm_ty Digest and rust_ty Digest);
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test() {
         ShadowedClosure::new(CompareBfes).test();
         ShadowedClosure::new(CompareDigests).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench() {
         ShadowedClosure::new(CompareBfes).bench();
         ShadowedClosure::new(CompareDigests).bench();

--- a/tasm-lib/src/data_type.rs
+++ b/tasm-lib/src/data_type.rs
@@ -444,14 +444,14 @@ impl Literal {
     /// - if the element is incorrectly [`BFieldCodec`] encoded
     pub fn pop_from_stack(data_type: DataType, stack: &mut Vec<BFieldElement>) -> Self {
         match data_type {
-            DataType::Bool => Self::Bool(pop_encodable(stack)),
-            DataType::U32 => Self::U32(pop_encodable(stack)),
-            DataType::U64 => Self::U64(pop_encodable(stack)),
-            DataType::U128 => Self::U128(pop_encodable(stack)),
-            DataType::I128 => Self::I128(pop_encodable(stack)),
-            DataType::Bfe => Self::Bfe(pop_encodable(stack)),
-            DataType::Xfe => Self::Xfe(pop_encodable(stack)),
-            DataType::Digest => Self::Digest(pop_encodable(stack)),
+            DataType::Bool => Self::Bool(pop_encodable(stack).unwrap()),
+            DataType::U32 => Self::U32(pop_encodable(stack).unwrap()),
+            DataType::U64 => Self::U64(pop_encodable(stack).unwrap()),
+            DataType::U128 => Self::U128(pop_encodable(stack).unwrap()),
+            DataType::I128 => Self::I128(pop_encodable(stack).unwrap()),
+            DataType::Bfe => Self::Bfe(pop_encodable(stack).unwrap()),
+            DataType::Xfe => Self::Xfe(pop_encodable(stack).unwrap()),
+            DataType::Digest => Self::Digest(pop_encodable(stack).unwrap()),
             DataType::List(_)
             | DataType::Array(_)
             | DataType::Tuple(_)
@@ -720,9 +720,10 @@ mod compare_literals {
             impl Closure for $name {
                 type Args = ($rust_ty, $rust_ty);
 
-                fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-                    let (right, left) = pop_encodable::<Self::Args>(stack);
+                fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError>{
+                    let (right, left) = pop_encodable::<Self::Args>(stack)?;
                     push_encodable(stack, &(left == right));
+                    Ok(())
                 }
 
                 fn pseudorandom_args(

--- a/tasm-lib/src/hashing/absorb_multiple.rs
+++ b/tasm-lib/src/hashing/absorb_multiple.rs
@@ -220,7 +220,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test() {
         ShadowedMemPreserver::new(AbsorbMultiple).test();
     }
@@ -231,7 +231,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedMemPreserver::new(AbsorbMultiple).bench();
     }

--- a/tasm-lib/src/hashing/absorb_multiple.rs
+++ b/tasm-lib/src/hashing/absorb_multiple.rs
@@ -162,14 +162,16 @@ mod tests {
             _: VecDeque<Digest>,
             _: VecDeque<BFieldElement>,
             sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
-            let length = pop_encodable::<u32>(stack).try_into().unwrap();
-            let address = stack.pop().unwrap();
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
+            let length = pop_encodable::<u32>(stack)?.try_into().unwrap();
+            let address = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
 
-            let sponge = sponge.as_mut().expect("sponge must be initialized");
+            let Some(sponge) = sponge.as_mut() else {
+                return Err(RustShadowError::SpongeUninitialized);
+            };
             sponge.pad_and_absorb_all(&array_from_memory::<BFieldElement>(address, length, memory));
 
-            vec![]
+            Ok(Vec::new())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/hashing/absorb_multiple_static_size.rs
+++ b/tasm-lib/src/hashing/absorb_multiple_static_size.rs
@@ -175,22 +175,22 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn absorb_multiple_static_size_0() {
         ShadowedProcedure::new(AbsorbMultipleStaticSize { size: 0 }).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn absorb_multiple_static_size_1() {
         ShadowedProcedure::new(AbsorbMultipleStaticSize { size: 1 }).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn absorb_multiple_static_size_9() {
         ShadowedProcedure::new(AbsorbMultipleStaticSize { size: 9 }).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn absorb_multiple_static_size_small_pbt() {
         for size in 0..30 {
             println!("Testing size {size}");
@@ -198,7 +198,7 @@ mod tests {
         }
     }
 
-    #[proptest(cases = 40)]
+    #[macro_rules_attr::apply(proptest(cases = 40))]
     fn absorb_multiple_static_size_pbt_pbt(#[strategy(arb())] size: u8) {
         ShadowedProcedure::new(AbsorbMultipleStaticSize {
             size: size as usize,
@@ -212,17 +212,17 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn absorb_multiple_static_size_benchmark_102() {
         ShadowedProcedure::new(AbsorbMultipleStaticSize { size: 102 }).bench();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn absorb_multiple_static_size_benchmark_400() {
         ShadowedProcedure::new(AbsorbMultipleStaticSize { size: 400 }).bench();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn absorb_multiple_static_size_benchmark_2002() {
         ShadowedProcedure::new(AbsorbMultipleStaticSize { size: 2002 }).bench();
     }

--- a/tasm-lib/src/hashing/absorb_multiple_static_size.rs
+++ b/tasm-lib/src/hashing/absorb_multiple_static_size.rs
@@ -102,10 +102,10 @@ impl BasicSnippet for AbsorbMultipleStaticSize {
 
 #[cfg(test)]
 mod tests {
-    use twenty_first::prelude::Sponge;
-
     use super::*;
     use crate::test_prelude::*;
+    use tasm_lib::USIZE_TO_U64_ERR;
+    use twenty_first::prelude::Sponge;
 
     impl Procedure for AbsorbMultipleStaticSize {
         fn rust_shadow(
@@ -115,28 +115,29 @@ mod tests {
             _: &NonDeterminism,
             _: &[BFieldElement],
             sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
             // read arguments
-            let address = stack.pop().unwrap();
+            let address = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
 
             // read sequence from memory
-            let mut sequence = vec![];
+            let mut sequence = Vec::new();
             for i in 0..self.size {
-                sequence.push(
-                    memory
-                        .get(&(address + BFieldElement::new(i as u64)))
-                        .copied()
-                        .unwrap(),
-                )
+                let mem_value = memory
+                    .get(&(address + BFieldElement::new(i as u64)))
+                    .copied()
+                    .ok_or(RustShadowError::Other)?;
+                sequence.push(mem_value)
             }
 
-            let sponge = sponge.as_mut().expect("sponge must be initialized");
+            let Some(sponge) = sponge.as_mut() else {
+                return Err(RustShadowError::SpongeUninitialized);
+            };
             sponge.pad_and_absorb_all(&sequence);
 
-            stack.push(address + BFieldElement::new(self.size.try_into().unwrap()));
+            stack.push(address + BFieldElement::new(self.size.try_into().expect(USIZE_TO_U64_ERR)));
 
             // output empty
-            vec![]
+            Ok(Vec::new())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/hashing/algebraic_hasher/hash_static_size.rs
+++ b/tasm-lib/src/hashing/algebraic_hasher/hash_static_size.rs
@@ -27,7 +27,7 @@ impl BasicSnippet for HashStaticSize {
         )
     }
 
-    fn code(&self, library: &mut crate::library::Library) -> Vec<LabelledInstruction> {
+    fn code(&self, library: &mut Library) -> Vec<LabelledInstruction> {
         let entrypoint = self.entrypoint();
         let absorb_subroutine =
             library.import(Box::new(AbsorbMultipleStaticSize { size: self.size }));
@@ -82,27 +82,30 @@ mod tests {
             nondeterminism: &NonDeterminism,
             public_input: &[BFieldElement],
             sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
             *sponge = Some(Tip5::init());
 
             let absorb_snippet = AbsorbMultipleStaticSize { size: self.size };
-            absorb_snippet.rust_shadow(stack, memory, nondeterminism, public_input, sponge);
+            absorb_snippet.rust_shadow(stack, memory, nondeterminism, public_input, sponge)?;
 
             // Sponge-squeeze
-            let mut squeezed = sponge.as_mut().unwrap().squeeze();
+            let Some(sponge) = sponge.as_mut() else {
+                return Err(RustShadowError::SpongeUninitialized);
+            };
+            let mut squeezed = sponge.squeeze();
             squeezed.reverse();
             stack.extend(squeezed);
 
             // Pop returned digest
-            let digest = pop_encodable::<Digest>(stack);
+            let digest = pop_encodable::<Digest>(stack)?;
 
             // Remove 5 more words:
             for _ in 0..Digest::LEN {
-                stack.pop().unwrap();
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?;
             }
 
             // Remove pointer
-            let input_pointer_plus_size = stack.pop().unwrap();
+            let input_pointer_plus_size = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
 
             // Put digest back on stack
             stack.extend(digest.reversed().values().to_vec());
@@ -111,7 +114,7 @@ mod tests {
 
             // _ d4 d3 d2 d1 d0 *ret_addr
 
-            vec![]
+            Ok(Vec::new())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/hashing/algebraic_hasher/hash_static_size.rs
+++ b/tasm-lib/src/hashing/algebraic_hasher/hash_static_size.rs
@@ -58,7 +58,7 @@ mod tests {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn hash_static_size_small_pbt() {
         for size in 0..20 {
             println!("Testing size {size}");
@@ -66,7 +66,7 @@ mod tests {
         }
     }
 
-    #[proptest(cases = 50)]
+    #[macro_rules_attr::apply(proptest(cases = 50))]
     fn hash_static_size_pbt_pbt(#[strategy(arb())] size: u8) {
         ShadowedProcedure::new(HashStaticSize {
             size: size as usize,
@@ -142,25 +142,25 @@ mod benches {
     use crate::test_prelude::*;
 
     // Picked to be the size of a main table row at time of writing
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn hash_var_lenstatic_size_benchmark_356() {
         ShadowedProcedure::new(HashStaticSize { size: 356 }).bench();
     }
 
     // Picked to be the size of a auxiliary table row at time of writing
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn hash_var_lenstatic_size_benchmark_249() {
         ShadowedProcedure::new(HashStaticSize { size: 249 }).bench();
     }
 
     // Picked to be the size of a quotient table row at time of writing
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn hash_var_lenstatic_size_benchmark_12() {
         ShadowedProcedure::new(HashStaticSize { size: 12 }).bench();
     }
 
     // Picked to compare with same size of benchmark for `hash_varlen` at time of writing
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn hash_var_lenstatic_size_benchmark_1000() {
         ShadowedProcedure::new(HashStaticSize { size: 1000 }).bench();
     }

--- a/tasm-lib/src/hashing/algebraic_hasher/hash_varlen.rs
+++ b/tasm-lib/src/hashing/algebraic_hasher/hash_varlen.rs
@@ -123,7 +123,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test() {
         ShadowedMemPreserver::new(HashVarlen).test();
     }
@@ -134,7 +134,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedMemPreserver::new(HashVarlen).bench();
     }

--- a/tasm-lib/src/hashing/algebraic_hasher/hash_varlen.rs
+++ b/tasm-lib/src/hashing/algebraic_hasher/hash_varlen.rs
@@ -88,14 +88,16 @@ mod tests {
             nd_digests: VecDeque<Digest>,
             stdin: VecDeque<BFieldElement>,
             sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
             *sponge = Some(Tip5::init());
-
-            AbsorbMultiple.rust_shadow(stack, memory, nd_tokens, nd_digests, stdin, sponge);
-            let [d0, d1, d2, d3, d4, ..] = sponge.as_mut().unwrap().squeeze();
+            AbsorbMultiple.rust_shadow(stack, memory, nd_tokens, nd_digests, stdin, sponge)?;
+            let Some(sponge) = sponge.as_mut() else {
+                return Err(RustShadowError::SpongeUninitialized);
+            };
+            let [d0, d1, d2, d3, d4, ..] = sponge.squeeze();
             push_encodable(stack, &Digest::new([d0, d1, d2, d3, d4]));
 
-            vec![]
+            Ok(Vec::new())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/hashing/algebraic_hasher/sample_indices.rs
+++ b/tasm-lib/src/hashing/algebraic_hasher/sample_indices.rs
@@ -216,7 +216,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test() {
         ShadowedProcedure::new(SampleIndices).test();
     }
@@ -227,7 +227,7 @@ mod bench {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedProcedure::new(SampleIndices).bench();
     }

--- a/tasm-lib/src/hashing/algebraic_hasher/sample_indices.rs
+++ b/tasm-lib/src/hashing/algebraic_hasher/sample_indices.rs
@@ -140,12 +140,14 @@ mod tests {
             _: &NonDeterminism,
             _: &[BFieldElement],
             sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
-            let sponge = sponge.as_mut().expect("sponge must be initialized");
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
+            let Some(sponge) = sponge.as_mut() else {
+                return Err(RustShadowError::SpongeUninitialized);
+            };
 
             // collect upper bound and number from stack
-            let upper_bound = stack.pop().unwrap().value() as u32;
-            let number = stack.pop().unwrap().value() as usize;
+            let upper_bound = stack.pop().ok_or(RustShadowError::StackUnderflow)?.value() as u32;
+            let number = stack.pop().ok_or(RustShadowError::StackUnderflow)?.value() as usize;
 
             println!("sampling {number} indices between 0 and {upper_bound}");
             println!("sponge before: {}", sponge.state.iter().join(","));
@@ -163,13 +165,13 @@ mod tests {
                     list_pointer,
                     vec![BFieldElement::new(*index as u64)],
                     memory,
-                );
+                )?;
             }
             println!("sponge after: {}", sponge.state.iter().join(","));
 
             stack.push(list_pointer);
 
-            vec![]
+            Ok(Vec::new())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/hashing/algebraic_hasher/sample_scalar_one.rs
+++ b/tasm-lib/src/hashing/algebraic_hasher/sample_scalar_one.rs
@@ -65,14 +65,17 @@ mod tests {
             _nondeterminism: &NonDeterminism,
             _public_input: &[BFieldElement],
             sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
-            let vals = sponge.as_mut().unwrap().squeeze();
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
+            let Some(sponge) = sponge.as_mut() else {
+                return Err(RustShadowError::SpongeUninitialized);
+            };
+            let vals = sponge.squeeze();
 
             for word in vals.iter().take(EXTENSION_DEGREE).rev() {
                 stack.push(*word)
             }
 
-            vec![]
+            Ok(Vec::new())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/hashing/algebraic_hasher/sample_scalar_one.rs
+++ b/tasm-lib/src/hashing/algebraic_hasher/sample_scalar_one.rs
@@ -52,7 +52,7 @@ mod tests {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn sample_scalar_one_test() {
         ShadowedProcedure::new(SampleScalarOne).test();
     }

--- a/tasm-lib/src/hashing/algebraic_hasher/sample_scalars.rs
+++ b/tasm-lib/src/hashing/algebraic_hasher/sample_scalars.rs
@@ -190,7 +190,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test() {
         ShadowedProcedure::new(SampleScalars).test();
     }
@@ -198,7 +198,7 @@ mod tests {
     /// This is a regression test that verifies that this implementation of `sample_scalars`
     /// agrees with Tip5's version from twenty-first. For the bugfix, see:
     /// <https://github.com/Neptune-Crypto/twenty-first/commit/e708b305>
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn verify_agreement_with_tip5_sample_scalars() {
         let empty_sponge = Tip5::init();
         let mut non_empty_sponge = Tip5::init();
@@ -246,7 +246,7 @@ mod bench {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedProcedure::new(SampleScalars).bench();
     }

--- a/tasm-lib/src/hashing/algebraic_hasher/sample_scalars.rs
+++ b/tasm-lib/src/hashing/algebraic_hasher/sample_scalars.rs
@@ -97,9 +97,11 @@ mod tests {
             _: &NonDeterminism,
             _: &[BFieldElement],
             sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
-            let sponge = sponge.as_mut().expect("sponge must be initialized");
-            let num_scalars = stack.pop().unwrap().value() as usize;
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
+            let Some(sponge) = sponge.as_mut() else {
+                return Err(RustShadowError::SpongeUninitialized);
+            };
+            let num_scalars = stack.pop().ok_or(RustShadowError::StackUnderflow)?.value() as usize;
             let num_squeezes = (num_scalars * 3 + 9) / tip5::RATE;
             let pseudorandomness = (0..num_squeezes)
                 .flat_map(|_| sponge.squeeze().to_vec())
@@ -124,9 +126,9 @@ mod tests {
 
             // the list of scalars was allocated properly; reflect that fact
             memory.insert(scalars_pointer, BFieldElement::new(num_scalars as u64));
-
             stack.push(scalars_pointer);
-            vec![]
+
+            Ok(Vec::new())
         }
 
         fn pseudorandom_initial_state(
@@ -217,7 +219,8 @@ mod tests {
                     &[],
                     NonDeterminism::default(),
                     &Some(init_sponge.clone()),
-                );
+                )
+                .unwrap();
 
                 let final_ram = tasm.ram;
                 let snippet_output_scalar_pointer =
@@ -234,6 +237,7 @@ mod tests {
                             &final_ram,
                             EXTENSION_DEGREE
                         )
+                        .unwrap()
                     );
                 }
             }

--- a/tasm-lib/src/hashing/algebraic_hasher/sample_scalars_static_length_dyn_malloc.rs
+++ b/tasm-lib/src/hashing/algebraic_hasher/sample_scalars_static_length_dyn_malloc.rs
@@ -91,12 +91,14 @@ mod tests {
         fn rust_shadow(
             &self,
             stack: &mut Vec<BFieldElement>,
-            memory: &mut std::collections::HashMap<BFieldElement, BFieldElement>,
+            memory: &mut HashMap<BFieldElement, BFieldElement>,
             _nondeterminism: &NonDeterminism,
             _public_input: &[BFieldElement],
             sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
-            let sponge = sponge.as_mut().expect("sponge must be initialized");
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
+            let Some(sponge) = sponge.as_mut() else {
+                return Err(RustShadowError::SpongeUninitialized);
+            };
             let num_squeezes = Self::num_squeezes(self.num_elements);
             let pseudorandomness = (0..num_squeezes)
                 .flat_map(|_| sponge.squeeze().to_vec())
@@ -109,7 +111,7 @@ mod tests {
                 memory.insert(BFieldElement::new(i as u64) + scalars_pointer, *pr);
             }
 
-            vec![]
+            Ok(Vec::new())
         }
 
         fn pseudorandom_initial_state(
@@ -154,7 +156,8 @@ mod tests {
                     &[],
                     NonDeterminism::default(),
                     &Some(init_sponge.clone()),
-                );
+                )
+                .unwrap();
 
                 let final_ram = tasm.ram;
                 let snippet_output_scalar_pointer =

--- a/tasm-lib/src/hashing/algebraic_hasher/sample_scalars_static_length_dyn_malloc.rs
+++ b/tasm-lib/src/hashing/algebraic_hasher/sample_scalars_static_length_dyn_malloc.rs
@@ -131,14 +131,14 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn sample_scalars_static_length_pbt() {
         for i in 0..100 {
             ShadowedProcedure::new(SampleScalarsStaticLengthDynMalloc { num_elements: i }).test();
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn verify_agreement_with_tip5_sample_scalars() {
         let empty_sponge = Tip5::init();
         let mut non_empty_sponge = Tip5::init();
@@ -184,17 +184,17 @@ mod bench {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_10() {
         ShadowedProcedure::new(SampleScalarsStaticLengthDynMalloc { num_elements: 10 }).bench();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_100() {
         ShadowedProcedure::new(SampleScalarsStaticLengthDynMalloc { num_elements: 100 }).bench();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_63() {
         ShadowedProcedure::new(SampleScalarsStaticLengthDynMalloc { num_elements: 63 }).bench();
     }

--- a/tasm-lib/src/hashing/algebraic_hasher/sample_scalars_static_length_kmalloc.rs
+++ b/tasm-lib/src/hashing/algebraic_hasher/sample_scalars_static_length_kmalloc.rs
@@ -104,12 +104,14 @@ pub(crate) mod tests {
         fn rust_shadow(
             &self,
             _stack: &mut Vec<BFieldElement>,
-            memory: &mut std::collections::HashMap<BFieldElement, BFieldElement>,
+            memory: &mut HashMap<BFieldElement, BFieldElement>,
             _nondeterminism: &NonDeterminism,
             _public_input: &[BFieldElement],
             sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
-            let sponge = sponge.as_mut().expect("sponge must be initialized");
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
+            let Some(sponge) = sponge.as_mut() else {
+                return Err(RustShadowError::SpongeUninitialized);
+            };
             let num_squeezes =
                 SampleScalarsStaticLengthDynMalloc::num_squeezes(self.num_elements_to_sample);
             let pseudorandomness = (0..num_squeezes)
@@ -118,7 +120,7 @@ pub(crate) mod tests {
             let scalars_pointer = self.k_malloc_address_isolated_run();
             insert_as_array(scalars_pointer, memory, pseudorandomness);
 
-            vec![]
+            Ok(Vec::new())
         }
 
         fn pseudorandom_initial_state(
@@ -183,7 +185,8 @@ pub(crate) mod tests {
             &[],
             NonDeterminism::default(),
             &Some(sponge.clone()),
-        );
+        )
+        .unwrap();
 
         let scalar_pointer = snippet.k_malloc_address_isolated_run();
         let read_scalar = |i| array_get(scalar_pointer, i, &tasm.ram, EXTENSION_DEGREE);

--- a/tasm-lib/src/hashing/algebraic_hasher/sample_scalars_static_length_kmalloc.rs
+++ b/tasm-lib/src/hashing/algebraic_hasher/sample_scalars_static_length_kmalloc.rs
@@ -150,7 +150,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn sample_scalars_static_length_pbt() {
         for num_elements_to_sample in 0..11 {
             for extra_capacity in 0..11 {
@@ -166,7 +166,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn verify_agreement_with_tip5_sample_scalars(
         #[strategy(1_usize..500)] num_elements_to_sample: usize,
         #[strategy(1_usize..500)] extra_capacity: usize,
@@ -200,7 +200,7 @@ mod bench {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_10() {
         ShadowedProcedure::new(SampleScalarsStaticLengthKMalloc {
             num_elements_to_sample: 10,
@@ -209,7 +209,7 @@ mod bench {
         .bench();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_100() {
         ShadowedProcedure::new(SampleScalarsStaticLengthKMalloc {
             num_elements_to_sample: 100,
@@ -218,7 +218,7 @@ mod bench {
         .bench();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_63() {
         ShadowedProcedure::new(SampleScalarsStaticLengthKMalloc {
             num_elements_to_sample: 63,

--- a/tasm-lib/src/hashing/algebraic_hasher/sample_scalars_static_length_static_pointer.rs
+++ b/tasm-lib/src/hashing/algebraic_hasher/sample_scalars_static_length_static_pointer.rs
@@ -89,8 +89,10 @@ pub(crate) mod tests {
             _: &NonDeterminism,
             _: &[BFieldElement],
             sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
-            let sponge = sponge.as_mut().expect("sponge must be initialized");
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
+            let Some(sponge) = sponge.as_mut() else {
+                return Err(RustShadowError::SpongeUninitialized);
+            };
             let num_squeezes =
                 SampleScalarsStaticLengthDynMalloc::num_squeezes(self.num_elements_to_sample);
             let pseudorandomness = (0..num_squeezes)
@@ -99,13 +101,13 @@ pub(crate) mod tests {
             let scalars_pointer = self.scalars_pointer;
             insert_as_array(scalars_pointer, memory, pseudorandomness);
 
-            vec![]
+            Ok(Vec::new())
         }
 
         fn pseudorandom_initial_state(
             &self,
             seed: [u8; 32],
-            _bench_case: Option<crate::snippet_bencher::BenchmarkCase>,
+            _bench_case: Option<BenchmarkCase>,
         ) -> ProcedureInitialState {
             let mut rng = StdRng::from_seed(seed);
             let stack = self.init_stack_for_isolated_run();
@@ -168,7 +170,8 @@ pub(crate) mod tests {
             &[],
             NonDeterminism::default(),
             &Some(sponge.clone()),
-        );
+        )
+        .unwrap();
 
         let scalar_pointer = snippet.scalars_pointer;
         let read_scalar = |i| array_get(scalar_pointer, i, &tasm.ram, EXTENSION_DEGREE);

--- a/tasm-lib/src/hashing/algebraic_hasher/sample_scalars_static_length_static_pointer.rs
+++ b/tasm-lib/src/hashing/algebraic_hasher/sample_scalars_static_length_static_pointer.rs
@@ -131,7 +131,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn sample_scalars_static_length_pbt() {
         for num_elements_to_sample in 0..11 {
             for extra_capacity in 0..11 {
@@ -149,7 +149,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn verify_agreement_with_tip5_sample_scalars(
         #[strategy(0_usize..500)] num_elements_to_sample: usize,
         #[strategy(0_usize..500)] extra_capacity: usize,
@@ -186,7 +186,7 @@ mod bench {
     use crate::test_prelude::*;
     use crate::verifier::challenges::shared::conventional_challenges_pointer;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_10() {
         ShadowedProcedure::new(SampleScalarsStaticLengthStaticPointer {
             num_elements_to_sample: 10,
@@ -196,7 +196,7 @@ mod bench {
         .bench();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_100() {
         ShadowedProcedure::new(SampleScalarsStaticLengthStaticPointer {
             num_elements_to_sample: 100,
@@ -206,7 +206,7 @@ mod bench {
         .bench();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_63() {
         ShadowedProcedure::new(SampleScalarsStaticLengthStaticPointer {
             num_elements_to_sample: 63,

--- a/tasm-lib/src/hashing/hash_from_stack.rs
+++ b/tasm-lib/src/hashing/hash_from_stack.rs
@@ -105,7 +105,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn unit() {
         let types = [
             DataType::Bool,
@@ -127,7 +127,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         let types = [DataType::Bfe, DataType::Digest];
         for data_type in types {

--- a/tasm-lib/src/hashing/hash_from_stack.rs
+++ b/tasm-lib/src/hashing/hash_from_stack.rs
@@ -84,13 +84,14 @@ mod tests {
     impl Closure for HashFromStack {
         type Args = Vec<BFieldElement>;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
             let mut preimage = vec![];
             for _ in 0..self.ty_len {
-                preimage.push(stack.pop().unwrap());
+                preimage.push(stack.pop().ok_or(RustShadowError::StackUnderflow)?);
             }
 
             push_encodable(stack, &Tip5::hash_varlen(&preimage));
+            Ok(())
         }
 
         fn pseudorandom_args(&self, seed: [u8; 32], _: Option<BenchmarkCase>) -> Self::Args {

--- a/tasm-lib/src/hashing/lt_digest.rs
+++ b/tasm-lib/src/hashing/lt_digest.rs
@@ -172,7 +172,7 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
+        ) -> Result<(), RustShadowError> {
             let load_digest = |ptr: BFieldElement| {
                 Digest::new([
                     memory[&ptr],
@@ -182,12 +182,13 @@ mod tests {
                     memory[&(ptr + bfe!(4))],
                 ])
             };
-            let rhs_ptr = stack.pop().unwrap();
-            let lhs_ptr = stack.pop().unwrap();
+            let rhs_ptr = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let lhs_ptr = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
             let rhs = load_digest(rhs_ptr);
             let lhs = load_digest(lhs_ptr);
 
             stack.push(bfe!((rhs < lhs) as u64));
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/hashing/lt_digest.rs
+++ b/tasm-lib/src/hashing/lt_digest.rs
@@ -249,7 +249,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedFunction::new(LtDigest).test()
     }
@@ -260,7 +260,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn lt_digest_bench() {
         ShadowedFunction::new(LtDigest).bench()
     }

--- a/tasm-lib/src/hashing/merkle_root.rs
+++ b/tasm-lib/src/hashing/merkle_root.rs
@@ -232,22 +232,24 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let leafs_pointer = stack.pop().unwrap();
-            let leafs = *Vec::decode_from_memory(memory, leafs_pointer).unwrap();
-            let mt = MerkleTree::par_new(&leafs).unwrap();
+        ) -> Result<(), RustShadowError> {
+            let leafs_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let leafs = *Vec::decode_from_memory(memory, leafs_pointer)
+                .map_err(|_| RustShadowError::DecodingError)?;
+            let mt = MerkleTree::par_new(&leafs).map_err(|_| RustShadowError::Other)?;
 
             // mimic snippet: write internal nodes to memory, skipping (dummy) node 0
             let tree_pointer = dynamic_allocator(memory);
             let num_internal_nodes = leafs.len();
 
             for node_index in 1..num_internal_nodes {
-                let node = mt.node(node_index).unwrap();
+                let node = mt.node(node_index).ok_or(RustShadowError::Other)?;
                 let node_address = tree_pointer + bfe!(node_index * Digest::LEN);
                 encode_to_memory(memory, node_address, &node);
             }
 
             stack.extend(mt.root().reversed().values());
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/hashing/merkle_root.rs
+++ b/tasm-lib/src/hashing/merkle_root.rs
@@ -275,12 +275,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedFunction::new(MerkleRoot).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn computing_root_of_tree_of_height_0_crashes_vm() {
         test_assertion_failure(
             &ShadowedFunction::new(MerkleRoot),
@@ -289,7 +289,7 @@ mod tests {
         );
     }
 
-    #[proptest(cases = 100)]
+    #[macro_rules_attr::apply(proptest(cases = 100))]
     fn computing_root_of_tree_of_height_not_power_of_2_crashes_vm(
         #[strategy(vec(arb(), 0..2048))]
         #[filter(!#leafs.len().is_power_of_two())]
@@ -309,7 +309,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(MerkleRoot).bench();
     }

--- a/tasm-lib/src/hashing/merkle_root_from_xfes.rs
+++ b/tasm-lib/src/hashing/merkle_root_from_xfes.rs
@@ -297,12 +297,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedFunction::new(MerkleRootFromXfes).test();
     }
 
-    #[proptest(cases = 100)]
+    #[macro_rules_attr::apply(proptest(cases = 100))]
     fn cannot_handle_input_list_of_length_not_pow2(
         #[strategy(vec(arb(), 0..2048))]
         #[filter(!#leafs.len().is_power_of_two())]
@@ -322,7 +322,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(MerkleRootFromXfes).bench();
     }

--- a/tasm-lib/src/hashing/merkle_root_from_xfes.rs
+++ b/tasm-lib/src/hashing/merkle_root_from_xfes.rs
@@ -240,15 +240,16 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let leafs_pointer = stack.pop().unwrap();
-            let leafs = *Vec::<XFieldElement>::decode_from_memory(memory, leafs_pointer).unwrap();
+        ) -> Result<(), RustShadowError> {
+            let leafs_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let leafs = *Vec::<XFieldElement>::decode_from_memory(memory, leafs_pointer)
+                .map_err(|_| RustShadowError::DecodingError)?;
             let leafs = leafs.into_iter().map(Digest::from).collect_vec();
-            let mt = MerkleTree::par_new(&leafs).unwrap();
+            let mt = MerkleTree::par_new(&leafs).map_err(|_| RustShadowError::Other)?;
 
             if leafs.len() == 1 {
                 stack.extend(mt.root().reversed().values());
-                return;
+                return Ok(());
             }
 
             // Write entire Merkle tree to memory, because that's what the VM does
@@ -256,21 +257,22 @@ mod tests {
             list_new(first_layer_pointer, memory);
             for node_count in 0..(leafs.len() >> 1) {
                 let node_index = node_count + (1 << (mt.height() - 1));
-                let node = mt.node(node_index).unwrap();
-                list_push(first_layer_pointer, node.values().to_vec(), memory)
+                let node = mt.node(node_index).ok_or(RustShadowError::Other)?;
+                list_push(first_layer_pointer, node.values().to_vec(), memory)?
             }
 
             let rest_of_tree_pointer = dynamic_allocator(memory);
             for layer in 2..=mt.height() {
                 for node_count in 0..(leafs.len() >> layer) {
                     let node_index = node_count + (1 << (mt.height() - layer));
-                    let node = mt.node(node_index).unwrap();
+                    let node = mt.node(node_index).ok_or(RustShadowError::Other)?;
                     let pointer = rest_of_tree_pointer + bfe!(node_index * Digest::LEN);
                     encode_to_memory(memory, pointer, &node);
                 }
             }
-
             stack.extend(mt.root().reversed().values());
+
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/hashing/merkle_step_mem_u64_index.rs
+++ b/tasm-lib/src/hashing/merkle_step_mem_u64_index.rs
@@ -105,13 +105,14 @@ mod tests {
             memory: &HashMap<BFieldElement, BFieldElement>,
             _: VecDeque<BFieldElement>,
             _: VecDeque<Digest>,
-        ) {
-            let stack_digest = pop_encodable::<Digest>(stack);
-            let leaf_index = pop_encodable::<u64>(stack);
-            let ram_ptr = pop_encodable::<BFieldElement>(stack);
+        ) -> Result<(), RustShadowError> {
+            let stack_digest = pop_encodable::<Digest>(stack)?;
+            let leaf_index = pop_encodable::<u64>(stack)?;
+            let ram_ptr = pop_encodable::<BFieldElement>(stack)?;
 
             let stack_digest_is_left_sibling = leaf_index.is_multiple_of(2);
-            let sibling_digest = *Digest::decode_from_memory(memory, ram_ptr).unwrap();
+            let sibling_digest = *Digest::decode_from_memory(memory, ram_ptr)
+                .map_err(|_| RustShadowError::DecodingError)?;
             let (left_digest, right_digest) = if stack_digest_is_left_sibling {
                 (stack_digest, sibling_digest)
             } else {
@@ -124,6 +125,8 @@ mod tests {
             push_encodable(stack, &(ram_ptr + bfe!(Digest::LEN)));
             push_encodable(stack, &parent_index);
             push_encodable(stack, &parent_digest);
+
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/hashing/merkle_step_mem_u64_index.rs
+++ b/tasm-lib/src/hashing/merkle_step_mem_u64_index.rs
@@ -142,7 +142,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn unit() {
         ShadowedReadOnlyAlgorithm::new(MerkleStepMemU64Index).test();
     }
@@ -153,7 +153,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedReadOnlyAlgorithm::new(MerkleStepMemU64Index).bench();
     }

--- a/tasm-lib/src/hashing/merkle_step_u64_index.rs
+++ b/tasm-lib/src/hashing/merkle_step_u64_index.rs
@@ -151,12 +151,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedReadOnlyAlgorithm::new(MerkleStepU64Index).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn unit_test() {
         fn assert_expected_behavior(mt_index: u64, expected_parent_index: u64) {
             let initial_state = MerkleStepU64Index.set_up_initial_state(mt_index);
@@ -194,7 +194,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedReadOnlyAlgorithm::new(MerkleStepU64Index).bench();
     }

--- a/tasm-lib/src/hashing/merkle_step_u64_index.rs
+++ b/tasm-lib/src/hashing/merkle_step_u64_index.rs
@@ -118,9 +118,9 @@ mod tests {
             _: &HashMap<BFieldElement, BFieldElement>,
             _: VecDeque<BFieldElement>,
             nd_digests: VecDeque<Digest>,
-        ) {
-            let stack_digest = pop_encodable::<Digest>(stack);
-            let leaf_index = pop_encodable::<u64>(stack);
+        ) -> Result<(), RustShadowError> {
+            let stack_digest = pop_encodable::<Digest>(stack)?;
+            let leaf_index = pop_encodable::<u64>(stack)?;
 
             let stack_digest_is_left_sibling = leaf_index.is_multiple_of(2);
             let (left_digest, right_digest) = if stack_digest_is_left_sibling {
@@ -134,6 +134,8 @@ mod tests {
 
             push_encodable(stack, &parent_index);
             push_encodable(stack, &parent_digest);
+
+            Ok(())
         }
 
         fn pseudorandom_initial_state(
@@ -166,11 +168,12 @@ mod tests {
                 &[],
                 initial_state.nondeterminism,
                 &None,
-            );
+            )
+            .unwrap();
 
             let mut final_stack = final_state.op_stack.stack;
-            let _ = pop_encodable::<Digest>(&mut final_stack);
-            let calculated_parent_index = pop_encodable::<u64>(&mut final_stack);
+            let _ = pop_encodable::<Digest>(&mut final_stack).unwrap();
+            let calculated_parent_index = pop_encodable::<u64>(&mut final_stack).unwrap();
 
             assert_eq!(expected_parent_index, calculated_parent_index);
             assert_eq!(mt_index / 2, calculated_parent_index);

--- a/tasm-lib/src/hashing/merkle_verify.rs
+++ b/tasm-lib/src/hashing/merkle_verify.rs
@@ -155,21 +155,27 @@ mod tests {
             _: &HashMap<BFieldElement, BFieldElement>,
             _: VecDeque<BFieldElement>,
             mut nd_digests: VecDeque<Digest>,
-        ) {
+        ) -> Result<(), RustShadowError> {
             // BEFORE: _ [root; 5] tree_height leaf_index [leaf; 5]
             // AFTER:  _
-            let leaf = pop_encodable(stack);
-            let leaf_index = pop_encodable::<u32>(stack);
-            let tree_height = pop_encodable::<u32>(stack);
-            let root = pop_encodable(stack);
+            let leaf = pop_encodable(stack)?;
+            let leaf_index = pop_encodable::<u32>(stack)?;
+            let tree_height = pop_encodable::<u32>(stack)?;
+            let root = pop_encodable(stack)?;
 
-            let num_leaves = 1 << tree_height;
-            assert!(leaf_index < num_leaves);
+            let num_leaves = 1_u32
+                .checked_shl(tree_height)
+                .ok_or(RustShadowError::ArithmeticOverflow)?;
+            if leaf_index >= num_leaves {
+                return Err(RustShadowError::InvalidProof);
+            }
 
             let mut node_digest = leaf;
             let mut node_index = leaf_index + num_leaves;
             while node_index != 1 {
-                let sibling = nd_digests.pop_front().unwrap();
+                let sibling = nd_digests
+                    .pop_front()
+                    .ok_or(RustShadowError::InvalidProof)?;
                 let node_is_left_sibling = node_index.is_multiple_of(2);
                 node_digest = if node_is_left_sibling {
                     Tip5::hash_pair(node_digest, sibling)
@@ -178,7 +184,11 @@ mod tests {
                 };
                 node_index /= 2;
             }
-            assert_eq!(node_digest, root);
+            if node_digest != root {
+                return Err(RustShadowError::InvalidProof);
+            }
+
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/hashing/merkle_verify.rs
+++ b/tasm-lib/src/hashing/merkle_verify.rs
@@ -228,12 +228,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn merkle_verify_test() {
         ShadowedReadOnlyAlgorithm::new(MerkleVerify).test()
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn merkle_tree_verification_fails_if_leaf_is_disturbed_slightly(
         seed: [u8; 32],
         #[strategy(0_usize..5)] perturbation_index: usize,
@@ -250,7 +250,7 @@ mod tests {
         );
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn merkle_tree_verification_fails_if_leaf_index_is_disturbed_slightly(
         seed: [u8; 32],
         #[filter(#perturbation != 0)] perturbation: i8,
@@ -271,7 +271,7 @@ mod tests {
         );
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn merkle_tree_verification_fails_if_leaf_index_is_out_of_range(
         seed: [u8; 32],
         #[strategy(u64::from(u32::MAX)..=BFieldElement::MAX)]
@@ -290,7 +290,7 @@ mod tests {
         );
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn merkle_tree_verification_fails_if_tree_height_is_disturbed_slightly(
         seed: [u8; 32],
         #[strategy(-32_i8..32)]
@@ -326,7 +326,7 @@ mod tests {
         );
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn merkle_tree_verification_fails_if_tree_height_is_too_large(
         seed: [u8; 32],
         #[strategy(32_u32..)] tree_height: u32,
@@ -343,7 +343,7 @@ mod tests {
         );
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn merkle_tree_verification_fails_if_tree_height_is_way_too_large(
         seed: [u8; 32],
         #[strategy(u64::from(u32::MAX)..=BFieldElement::MAX)]
@@ -362,7 +362,7 @@ mod tests {
         );
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn merkle_tree_verification_fails_if_root_is_disturbed_slightly(
         seed: [u8; 32],
         #[strategy(7_usize..12)] perturbation_index: usize,
@@ -385,7 +385,7 @@ mod bench {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedReadOnlyAlgorithm::new(MerkleVerify).bench()
     }

--- a/tasm-lib/src/hashing/sponge_hasher/absorb.rs
+++ b/tasm-lib/src/hashing/sponge_hasher/absorb.rs
@@ -148,7 +148,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn absorb_test() {
         ShadowedProcedure::new(Absorb).test();
     }
@@ -159,7 +159,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedProcedure::new(Absorb).bench();
     }

--- a/tasm-lib/src/hashing/sponge_hasher/absorb.rs
+++ b/tasm-lib/src/hashing/sponge_hasher/absorb.rs
@@ -102,16 +102,20 @@ mod tests {
             _nondeterminism: &NonDeterminism,
             _public_input: &[BFieldElement],
             sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
-            let sponge = sponge.as_mut().expect("sponge must be initialized");
-            let input_pointer: BFieldElement = stack.pop().unwrap();
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
+            let Some(sponge) = sponge.as_mut() else {
+                return Err(RustShadowError::SpongeUninitialized);
+            };
+            let input_pointer: BFieldElement =
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?;
             let input: [BFieldElement; 10] = (0..10)
                 .map(|i| memory[&(BFieldElement::new(i) + input_pointer)])
                 .collect_vec()
                 .try_into()
                 .unwrap();
             sponge.absorb(input);
-            Vec::default()
+
+            Ok(Vec::new())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/hashing/sponge_hasher/init.rs
+++ b/tasm-lib/src/hashing/sponge_hasher/init.rs
@@ -46,9 +46,9 @@ mod tests {
             _: &NonDeterminism,
             _: &[BFieldElement],
             sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
             *sponge = Some(Tip5::init());
-            vec![]
+            Ok(Vec::new())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/hashing/sponge_hasher/init.rs
+++ b/tasm-lib/src/hashing/sponge_hasher/init.rs
@@ -69,7 +69,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn sponge_init_test() {
         ShadowedProcedure::new(Init).test();
     }
@@ -80,7 +80,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedProcedure::new(Init).bench();
     }

--- a/tasm-lib/src/hashing/sponge_hasher/pad_and_absorb_all.rs
+++ b/tasm-lib/src/hashing/sponge_hasher/pad_and_absorb_all.rs
@@ -78,9 +78,12 @@ mod tests {
             _nondeterminism: &NonDeterminism,
             _public_input: &[BFieldElement],
             sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
-            let sponge = sponge.as_mut().expect("sponge must be initialized");
-            let input_pointer: BFieldElement = stack.pop().unwrap();
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
+            let Some(sponge) = sponge.as_mut() else {
+                return Err(RustShadowError::SpongeUninitialized);
+            };
+            let input_pointer: BFieldElement =
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?;
             let first_word = input_pointer + BFieldElement::new(LIST_METADATA_SIZE as u64);
             let input_length = memory[&input_pointer].value();
             let input = (0..input_length)
@@ -88,7 +91,7 @@ mod tests {
                 .collect_vec();
             sponge.pad_and_absorb_all(&input);
 
-            Vec::default()
+            Ok(Vec::new())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/hashing/sponge_hasher/pad_and_absorb_all.rs
+++ b/tasm-lib/src/hashing/sponge_hasher/pad_and_absorb_all.rs
@@ -155,7 +155,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn pad_and_absorb_all_test() {
         ShadowedProcedure::new(PadAndAbsorbAll).test();
     }

--- a/tasm-lib/src/hashing/sponge_hasher/squeeze.rs
+++ b/tasm-lib/src/hashing/sponge_hasher/squeeze.rs
@@ -122,7 +122,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn squeeze_test() {
         ShadowedProcedure::new(Squeeze).test();
     }
@@ -133,7 +133,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedProcedure::new(Squeeze).bench();
     }

--- a/tasm-lib/src/hashing/sponge_hasher/squeeze.rs
+++ b/tasm-lib/src/hashing/sponge_hasher/squeeze.rs
@@ -83,8 +83,10 @@ mod tests {
             _nondeterminism: &NonDeterminism,
             _public_input: &[BFieldElement],
             sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
-            let sponge = sponge.as_mut().expect("sponge must be initialized");
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
+            let Some(sponge) = sponge.as_mut() else {
+                return Err(RustShadowError::SpongeUninitialized);
+            };
             let mut array_pointer =
                 rust_shadowing_helper_functions::dyn_malloc::dynamic_allocator(memory);
             stack.push(array_pointer);
@@ -94,7 +96,7 @@ mod tests {
                 array_pointer.increment();
             }
 
-            Vec::default()
+            Ok(Vec::new())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/hashing/squeeze_repeatedly.rs
+++ b/tasm-lib/src/hashing/squeeze_repeatedly.rs
@@ -75,11 +75,13 @@ mod tests {
             _: &NonDeterminism,
             _: &[BFieldElement],
             sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
-            let num_squeezes = stack.pop().unwrap().value() as usize;
-            let address = stack.pop().unwrap();
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
+            let num_squeezes = stack.pop().ok_or(RustShadowError::StackUnderflow)?.value() as usize;
+            let address = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
 
-            let sponge = sponge.as_mut().expect("sponge must be initialized");
+            let Some(sponge) = sponge.as_mut() else {
+                return Err(RustShadowError::SpongeUninitialized);
+            };
             let sequence = (0..num_squeezes)
                 .flat_map(|_| sponge.squeeze().to_vec())
                 .collect_vec();
@@ -92,7 +94,7 @@ mod tests {
             stack.push(new_address);
             stack.push(BFieldElement::new(0));
 
-            vec![]
+            Ok(Vec::new())
         }
 
         fn pseudorandom_initial_state(
@@ -148,7 +150,7 @@ mod tests {
             let rust = rust_final_state(&shadow, &stack, &stdin, &nondeterminism, &sponge);
 
             // run tvm
-            let tasm = tasm_final_state(&shadow, &stack, &stdin, nondeterminism, &sponge);
+            let tasm = tasm_final_state(&shadow, &stack, &stdin, nondeterminism, &sponge).unwrap();
 
             assert_eq!(
                 rust.public_output, tasm.public_output,

--- a/tasm-lib/src/hashing/squeeze_repeatedly.rs
+++ b/tasm-lib/src/hashing/squeeze_repeatedly.rs
@@ -124,7 +124,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test() {
         // custom test procedure because it is a procedure but we do want to test memory equivalence
 
@@ -173,7 +173,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedProcedure::new(SqueezeRepeatedly).bench();
     }

--- a/tasm-lib/src/hashing/squeeze_repeatedly_static_number.rs
+++ b/tasm-lib/src/hashing/squeeze_repeatedly_static_number.rs
@@ -106,14 +106,14 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn squeeze_repeatedly_static_number_pbt() {
         for num_squeezes in 0..25 {
             ShadowedProcedure::new(SqueezeRepeatedlyStaticNumber { num_squeezes }).test();
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_dyn_equivalence() {
         // Verify that the snippets for the dynamically known and statically known
         // number of squeezes agree.
@@ -180,12 +180,12 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_10() {
         ShadowedProcedure::new(SqueezeRepeatedlyStaticNumber { num_squeezes: 10 }).bench();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_200() {
         ShadowedProcedure::new(SqueezeRepeatedlyStaticNumber { num_squeezes: 200 }).bench();
     }

--- a/tasm-lib/src/hashing/squeeze_repeatedly_static_number.rs
+++ b/tasm-lib/src/hashing/squeeze_repeatedly_static_number.rs
@@ -82,17 +82,16 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-            nondeterminism: &NonDeterminism,
+            nondet: &NonDeterminism,
             public_input: &[BFieldElement],
             sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
             stack.push(BFieldElement::new(self.num_squeezes as u64));
-            let ret =
-                SqueezeRepeatedly.rust_shadow(stack, memory, nondeterminism, public_input, sponge);
+            let ret = SqueezeRepeatedly.rust_shadow(stack, memory, nondet, public_input, sponge)?;
             stack.pop();
             stack.pop();
 
-            ret
+            Ok(ret)
         }
 
         fn pseudorandom_initial_state(
@@ -128,7 +127,7 @@ mod tests {
             let num_squeeze_count = stack.last().unwrap().value();
 
             (
-                tasm_final_state(&dyn_snippet, &stack, &stdin, nondeterminism, &sponge),
+                tasm_final_state(&dyn_snippet, &stack, &stdin, nondeterminism, &sponge).unwrap(),
                 num_squeeze_count as usize,
             )
         }
@@ -149,6 +148,7 @@ mod tests {
                 nondeterminism,
                 &sponge,
             )
+            .unwrap()
         }
 
         let mut seed = [0u8; 32];

--- a/tasm-lib/src/io/read_input.rs
+++ b/tasm-lib/src/io/read_input.rs
@@ -7,6 +7,7 @@ use crate::empty_stack;
 use crate::prelude::*;
 use crate::traits::procedure::Procedure;
 use crate::traits::procedure::ProcedureInitialState;
+use crate::traits::rust_shadow::RustShadowError;
 
 /// Move an element of type `DataType` from standard-in or secret-in's token stream to the stack
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -50,8 +51,8 @@ impl Procedure for ReadInput {
         _memory: &mut HashMap<BFieldElement, BFieldElement>,
         nondeterminism: &NonDeterminism,
         public_input: &[BFieldElement],
-        _sponge: &mut Option<crate::prelude::Tip5>,
-    ) -> Vec<BFieldElement> {
+        _sponge: &mut Option<Tip5>,
+    ) -> Result<Vec<BFieldElement>, RustShadowError> {
         let input_source = match self.input_source {
             InputSource::StdIn => public_input,
             InputSource::SecretIn => &nondeterminism.individual_tokens,
@@ -61,7 +62,7 @@ impl Procedure for ReadInput {
         }
 
         // Output nothing
-        vec![]
+        Ok(Vec::new())
     }
 
     fn pseudorandom_initial_state(

--- a/tasm-lib/src/io/read_input.rs
+++ b/tasm-lib/src/io/read_input.rs
@@ -90,7 +90,7 @@ mod tests {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test() {
         for data_type in DataType::big_random_generatable_type_collection() {
             ShadowedProcedure::new(ReadInput {
@@ -112,7 +112,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedProcedure::new(ReadInput {
             data_type: DataType::Digest,

--- a/tasm-lib/src/io/write_to_stdout.rs
+++ b/tasm-lib/src/io/write_to_stdout.rs
@@ -77,7 +77,7 @@ mod tests {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         for data_type in DataType::big_random_generatable_type_collection() {
             ShadowedProcedure::new(WriteToStdout { data_type }).test();
@@ -90,7 +90,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark_digest_writing() {
         ShadowedProcedure::new(WriteToStdout {
             data_type: DataType::Digest,

--- a/tasm-lib/src/io/write_to_stdout.rs
+++ b/tasm-lib/src/io/write_to_stdout.rs
@@ -7,6 +7,7 @@ use crate::empty_stack;
 use crate::prelude::*;
 use crate::traits::procedure::Procedure;
 use crate::traits::procedure::ProcedureInitialState;
+use crate::traits::rust_shadow::RustShadowError;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct WriteToStdout {
@@ -46,13 +47,14 @@ impl Procedure for WriteToStdout {
         _: &NonDeterminism,
         _: &[BFieldElement],
         _: &mut Option<Tip5>,
-    ) -> Vec<BFieldElement> {
-        let mut ret = vec![];
+    ) -> Result<Vec<BFieldElement>, RustShadowError> {
+        let mut ret = Vec::new();
         for _ in 0..self.data_type.stack_size() {
-            let value = stack.pop().unwrap();
+            let value = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
             ret.push(value);
         }
-        ret
+
+        Ok(ret)
     }
 
     fn pseudorandom_initial_state(

--- a/tasm-lib/src/lib.rs
+++ b/tasm-lib/src/lib.rs
@@ -49,6 +49,7 @@ use triton_vm::prelude::TableId;
 pub use triton_vm::twenty_first;
 
 use crate::test_helpers::prepend_program_with_stack_setup;
+use crate::traits::rust_shadow::RustShadowError;
 
 pub(crate) const U32_TO_USIZE_ERR: &str =
     "internal error: type `usize` should have at least 32 bits";
@@ -104,17 +105,24 @@ pub fn push_encodable<T: BFieldCodec>(stack: &mut Vec<BFieldElement>, value: &T)
 
 /// Pops an element of the specified, generic type from the stack.
 ///
-/// ### Panics
+/// ### Errors
 ///
-/// Panics if
+/// Errors if
 /// - the generic type has [dynamic length](BFieldCodec::static_length)
 /// - the stack does not contain enough elements
 /// - the top of the stack does not correspond to a [`BFieldCodec`] encoded
 ///   element of type `T`
-pub fn pop_encodable<T: BFieldCodec>(stack: &mut Vec<BFieldElement>) -> T {
-    let len = T::static_length().unwrap();
-    let limbs = (0..len).map(|_| stack.pop().unwrap()).collect_vec();
-    *T::decode(&limbs).unwrap()
+pub fn pop_encodable<T: BFieldCodec>(stack: &mut Vec<BFieldElement>) -> Result<T, RustShadowError> {
+    let Some(len) = T::static_length() else {
+        return Err(RustShadowError::Other);
+    };
+    let limbs: Vec<_> = (0..len)
+        .map(|_| stack.pop().ok_or(RustShadowError::StackUnderflow))
+        .try_collect()?;
+
+    T::decode(&limbs)
+        .map(|t| *t)
+        .map_err(|_| RustShadowError::DecodingError)
 }
 
 /// Execute a Triton-VM program and test correct behavior indicators.
@@ -126,7 +134,7 @@ pub(crate) fn execute_test(
     std_in: Vec<BFieldElement>,
     nondeterminism: NonDeterminism,
     maybe_sponge: Option<Tip5>,
-) -> VMState {
+) -> Result<VMState, RustShadowError> {
     let init_stack = stack.to_owned();
     let public_input = PublicInput::new(std_in.clone());
     let program = Program::new(code);
@@ -142,33 +150,36 @@ pub(crate) fn execute_test(
     maybe_write_debuggable_vm_state_to_disk(&vm_state);
 
     if let Err(err) = vm_state.run() {
-        panic!("{err}\n\nFinal state was: {vm_state}")
+        eprintln!("{err}\n\nFinal state was: {vm_state}");
+        return Err(RustShadowError::VmError);
     }
     let terminal_state = vm_state;
 
     if !terminal_state.jump_stack.is_empty() {
-        panic!("Jump stack must be unchanged after code execution");
+        eprintln!("Jump stack must be unchanged after code execution");
+        return Err(RustShadowError::VmError);
     }
 
     let final_stack_height = terminal_state.op_stack.stack.len() as isize;
     let initial_stack_height = init_stack.len();
-    assert_eq!(
-        expected_stack_diff,
-        final_stack_height - initial_stack_height as isize,
-        "Code must grow/shrink stack with expected number of elements.\n
-        init height: {initial_stack_height}\n
-        end height:  {final_stack_height}\n
-        expected difference: {expected_stack_diff}\n\n
-        initial stack: {}\n
-        final stack:   {}",
-        init_stack.iter().skip(NUM_OP_STACK_REGISTERS).join(","),
-        terminal_state
-            .op_stack
-            .stack
-            .iter()
-            .skip(NUM_OP_STACK_REGISTERS)
-            .join(","),
-    );
+    if expected_stack_diff != final_stack_height - initial_stack_height as isize {
+        eprintln!(
+            "Code must grow/shrink stack with expected number of elements.\n
+            init height: {initial_stack_height}\n
+            end height:  {final_stack_height}\n
+            expected difference: {expected_stack_diff}\n\n
+            initial stack: {}\n
+            final stack:   {}",
+            init_stack.iter().skip(NUM_OP_STACK_REGISTERS).join(","),
+            terminal_state
+                .op_stack
+                .stack
+                .iter()
+                .skip(NUM_OP_STACK_REGISTERS)
+                .join(","),
+        );
+        return Err(RustShadowError::VmError);
+    }
 
     // If this environment variable is set, all programs, including the code to prepare the state,
     // will be proven and then verified.
@@ -180,7 +191,7 @@ pub(crate) fn execute_test(
     }
 
     stack.clone_from(&terminal_state.op_stack.stack);
-    terminal_state
+    Ok(terminal_state)
 }
 
 /// If the environment variable TASMLIB_TRITON_TUI is set, write the initial VM state
@@ -435,4 +446,5 @@ pub mod test_prelude {
     pub use crate::traits::read_only_algorithm::ReadOnlyAlgorithmInitialState;
     pub use crate::traits::read_only_algorithm::ShadowedReadOnlyAlgorithm;
     pub use crate::traits::rust_shadow::RustShadow;
+    pub use crate::traits::rust_shadow::RustShadowError;
 }

--- a/tasm-lib/src/lib.rs
+++ b/tasm-lib/src/lib.rs
@@ -14,13 +14,13 @@ extern crate self as tasm_lib;
 
 use std::collections::HashMap;
 use std::io::Write;
-use std::time::SystemTime;
 
 use itertools::Itertools;
 use memory::dyn_malloc;
 use num_traits::Zero;
 use triton_vm::isa::op_stack::NUM_OP_STACK_REGISTERS;
 use triton_vm::prelude::*;
+use web_time::SystemTime;
 
 pub mod arithmetic;
 pub mod array;
@@ -328,11 +328,76 @@ pub fn generate_full_profile(
 /// Feel free to add anything you frequently `use` in a test module.
 #[cfg(test)]
 pub mod test_prelude {
+    /// A crate-specific replacement of the `#[test]` attribute for tests that
+    /// should also be executed on `wasm` targets (which is almost all tests).
+    ///
+    /// If you specifically want to exclude a test from `wasm` targets, use the
+    /// usual `#[test]` attribute instead.
+    ///
+    /// # Usage
+    ///
+    /// ```
+    /// #[macro_rules_attr::apply(test)]
+    /// fn foo() {
+    ///     assert_eq!(4, 2 + 2);
+    /// }
+    /// ```
+    macro_rules! test {
+        ($item:item) => {
+            #[test]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+            $item
+        };
+    }
+    pub(crate) use test;
+
+    /// A crate-specific replacement of the `#[test_strategy::proptest]`
+    /// attribute for tests that should also be executed on `wasm` targets
+    /// (which is almost all tests).
+    ///
+    /// If you specifically want to exclude a test from `wasm` targets, use the
+    /// usual `#[test_strategy::proptest]` attribute instead.
+    ///
+    /// # Usage
+    ///
+    /// ```
+    /// # use proptest::prop_assert_eq;
+    /// #[macro_rules_attr::apply(proptest)]
+    /// fn foo(#[strategy(0..=42)] x: i32) {
+    ///     prop_assert_eq!(2 * x, x + x);
+    /// }
+    /// ```
+    ///
+    /// If you want to configure the test, use the usual syntax defined by
+    /// [`test_strategy`]:
+    /// ```
+    /// # use proptest::prop_assert_eq;
+    /// #[macro_rules_attr::apply(proptest(cases = 10, max_local_rejects = 5))]
+    /// fn foo(#[strategy(0..=42)] x: i32) {
+    ///     prop_assert_eq!(2 * x, x + x);
+    /// }
+    /// ```
+    macro_rules! proptest {
+        ($item:item $(($($config:tt)*))?) => {
+            #[test_strategy::proptest $(($($config)*))?]
+            #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+            $item
+        };
+    }
+    pub(crate) use proptest;
+
     pub use std::collections::HashMap;
 
     pub use itertools::Itertools;
-    pub use proptest::prelude::*;
-    pub use proptest_arbitrary_interop::arb;
+    pub use proptest::prelude::Just;
+    pub use proptest::prelude::Strategy;
+    pub use proptest::prelude::TestCaseError;
+    pub use proptest::prelude::any;
+    pub use proptest::prelude::prop_assert;
+    pub use proptest::prelude::prop_assert_eq;
+    pub use proptest::prelude::prop_assume;
+    pub use proptest::test_runner::TestCaseResult;
+    pub use proptest_arbitrary_adapter::arb;
     pub use rand::Rng;
     pub use rand::RngCore;
     pub use rand::SeedableRng;
@@ -340,7 +405,7 @@ pub mod test_prelude {
     pub use rand::prelude::IndexedRandom;
     pub use rand::prelude::IteratorRandom;
     pub use rand::rngs::StdRng;
-    pub use test_strategy::proptest;
+    pub use test_strategy::Arbitrary;
 
     pub use crate::InitVmState;
     pub use crate::memory::encode_to_memory;

--- a/tasm-lib/src/library.rs
+++ b/tasm-lib/src/library.rs
@@ -267,8 +267,9 @@ mod tests {
     impl Closure for DummyTestSnippetA {
         type Args = ZeroSizedType;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
             push_encodable(stack, &xfe![[1, 1, 1]]);
+            Ok(())
         }
 
         fn pseudorandom_args(&self, _: [u8; 32], _: Option<BenchmarkCase>) -> Self::Args {
@@ -279,9 +280,10 @@ mod tests {
     impl Closure for DummyTestSnippetB {
         type Args = ZeroSizedType;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
             stack.push(bfe!(1));
             stack.push(bfe!(1));
+            Ok(())
         }
 
         fn pseudorandom_args(&self, _: [u8; 32], _: Option<BenchmarkCase>) -> Self::Args {
@@ -292,8 +294,9 @@ mod tests {
     impl Closure for DummyTestSnippetC {
         type Args = ZeroSizedType;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
             stack.push(bfe!(1));
+            Ok(())
         }
 
         fn pseudorandom_args(&self, _: [u8; 32], _: Option<BenchmarkCase>) -> Self::Args {

--- a/tasm-lib/src/library.rs
+++ b/tasm-lib/src/library.rs
@@ -68,7 +68,7 @@ impl Default for Library {
 
 impl Library {
     pub fn kmalloc_memory_region() -> MemoryRegion {
-        MemoryRegion::new(STATIC_MEMORY_LAST_ADDRESS, 1usize << 32)
+        MemoryRegion::new(STATIC_MEMORY_LAST_ADDRESS, 1 << 32)
     }
 
     pub fn new() -> Self {
@@ -301,14 +301,14 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn library_includes() {
         ShadowedClosure::new(DummyTestSnippetA).test();
         ShadowedClosure::new(DummyTestSnippetB).test();
         ShadowedClosure::new(DummyTestSnippetC).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn get_all_snippet_names_test_a() {
         let mut lib = Library::new();
         lib.import(Box::new(DummyTestSnippetA));
@@ -322,7 +322,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn get_all_snippet_names_test_b() {
         let mut lib = Library::new();
         lib.import(Box::new(DummyTestSnippetB));
@@ -332,7 +332,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn all_imports_as_instruction_lists() {
         let mut lib = Library::new();
         lib.import(Box::new(DummyTestSnippetA));
@@ -341,7 +341,7 @@ mod tests {
         let _ret = lib.all_imports();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn program_is_deterministic() {
         // Ensure that a generated program is deterministic, by checking that the imports
         // are always sorted the same way.
@@ -380,7 +380,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn kmalloc_test() {
         const MINUS_TWO: BFieldElement = BFieldElement::new(BFieldElement::MAX - 1);
         let mut lib = Library::new();

--- a/tasm-lib/src/list/contains.rs
+++ b/tasm-lib/src/list/contains.rs
@@ -301,7 +301,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         for element_type in [
             DataType::Bfe,
@@ -316,7 +316,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn contains_returns_true_on_contained_value() {
         let snippet = Contains::new(DataType::U64);
         let a_u64_element = bfe_vec![2, 3];
@@ -336,7 +336,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn contains_returns_false_on_mirrored_value() {
         let snippet = Contains::new(DataType::U64);
         let a_u64_element = bfe_vec![2, 3];
@@ -362,7 +362,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         for element_type in [DataType::U64, DataType::Digest] {
             ShadowedFunction::new(Contains::new(element_type)).bench();

--- a/tasm-lib/src/list/contains.rs
+++ b/tasm-lib/src/list/contains.rs
@@ -184,14 +184,14 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
+        ) -> Result<(), RustShadowError> {
             let needle = (0..self.element_type.stack_size())
-                .map(|_| stack.pop().unwrap())
-                .collect_vec();
+                .map(|_| stack.pop().ok_or(RustShadowError::StackUnderflow))
+                .try_collect()?;
 
-            let haystack_list_ptr = stack.pop().unwrap();
+            let haystack_list_ptr = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
             let haystack_elems =
-                load_list_unstructured(self.element_type.stack_size(), haystack_list_ptr, memory);
+                load_list_unstructured(self.element_type.stack_size(), haystack_list_ptr, memory)?;
 
             stack.push(bfe!(haystack_elems.contains(&needle) as u32));
 
@@ -201,6 +201,8 @@ mod tests {
                 memory.insert(static_pointer, word);
                 static_pointer.increment();
             }
+
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/list/get.rs
+++ b/tasm-lib/src/list/get.rs
@@ -141,7 +141,7 @@ pub(crate) mod tests {
 
         pub fn random_len_idx_ptr(
             bench_case: Option<BenchmarkCase>,
-            rng: &mut impl rand::Rng,
+            rng: &mut impl Rng,
         ) -> (usize, usize, BFieldElement) {
             let (index, list_length) = match bench_case {
                 Some(BenchmarkCase::CommonCase) => (16, 32),
@@ -162,15 +162,23 @@ pub(crate) mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let index: u32 = stack.pop().unwrap().try_into().unwrap();
-            let list_pointer = stack.pop().unwrap();
+        ) -> Result<(), RustShadowError> {
+            let index: u32 = stack
+                .pop()
+                .ok_or(RustShadowError::StackUnderflow)?
+                .try_into()
+                .map_err(|_| RustShadowError::U64ToU32Error)?;
+            let list_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
 
             let index: usize = index.try_into().expect(U32_TO_USIZE_ERR);
-            let element_length = self.element_type.static_length().unwrap();
-            let element = list_get(list_pointer, index, memory, element_length);
+            let element_length = self
+                .element_type
+                .static_length()
+                .ok_or(RustShadowError::Other)?;
+            let element = list_get(list_pointer, index, memory, element_length)?;
 
             stack.extend(element.into_iter().rev());
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/list/get.rs
+++ b/tasm-lib/src/list/get.rs
@@ -116,13 +116,10 @@ impl BasicSnippet for Get {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use triton_vm::error::OpStackError::FailedU32Conversion;
-
     use super::*;
     use crate::U32_TO_USIZE_ERR;
     use crate::rust_shadowing_helper_functions::list::insert_random_list;
     use crate::rust_shadowing_helper_functions::list::list_get;
-    use crate::test_helpers::negative_test;
     use crate::test_prelude::*;
 
     impl Get {
@@ -188,17 +185,17 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         for ty in [DataType::Bfe, DataType::Digest, DataType::I128] {
             ShadowedAccessor::new(Get::new(ty)).test();
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn out_of_bounds_access_crashes_vm(
         #[strategy(0_usize..=1_000)] list_length: usize,
-        #[strategy(#list_length..1 << 32)] index: usize,
+        #[strategy(#list_length..=u32::MAX.try_into().unwrap())] index: usize,
         #[strategy(arb())] list_pointer: BFieldElement,
     ) {
         let get = Get::new(DataType::Bfe);
@@ -210,16 +207,20 @@ pub(crate) mod tests {
         );
     }
 
-    #[proptest]
+    // Don't test on `wasm32`: too large indices cannot be represented there.
+    #[test_strategy::proptest]
+    #[cfg(not(target_arch = "wasm32"))]
     fn too_large_indices_crash_vm(
         #[strategy(1_usize << 32..)] index: usize,
         #[strategy(arb())] list_pointer: BFieldElement,
     ) {
+        use triton_vm::error::OpStackError::FailedU32Conversion;
+
         let list_length = 0;
         let get = Get::new(DataType::Bfe);
         let initial_state = get.set_up_initial_state(list_length, index, list_pointer);
         let expected_error = InstructionError::OpStackError(FailedU32Conversion(bfe!(index)));
-        negative_test(
+        crate::test_helpers::negative_test(
             &ShadowedAccessor::new(get),
             initial_state.into(),
             &[expected_error],
@@ -238,7 +239,7 @@ pub(crate) mod tests {
     /// element index must be at most [u32::MAX].
     ///
     /// [page size]: crate::memory::dyn_malloc::DYN_MALLOC_PAGE_SIZE
-    #[proptest(cases = 100)]
+    #[macro_rules_attr::apply(proptest(cases = 100))]
     fn too_large_lists_crash_vm(
         #[strategy(1_u64 << 22..1 << 32)] list_length: u64,
         #[strategy((1 << 22) - 1..#list_length)] index: u64,
@@ -269,7 +270,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedAccessor::new(Get::new(DataType::Digest)).bench();
     }

--- a/tasm-lib/src/list/higher_order/all.rs
+++ b/tasm-lib/src/list/higher_order/all.rs
@@ -178,27 +178,29 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
+        ) -> Result<(), RustShadowError> {
             let input_type = self.f.domain();
-            let list_pointer = stack.pop().unwrap();
+            let list_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
 
             // forall elements, read + map + maybe copy
             let list_length =
-                rust_shadowing_helper_functions::list::list_get_length(list_pointer, memory);
+                rust_shadowing_helper_functions::list::list_get_length(list_pointer, memory)?;
             let mut satisfied = true;
             for i in 0..list_length {
-                let input_item = list_get(list_pointer, i, memory, input_type.stack_size());
+                let input_item = list_get(list_pointer, i, memory, input_type.stack_size())?;
                 for bfe in input_item.into_iter().rev() {
                     stack.push(bfe);
                 }
 
                 self.f.apply(stack, memory);
 
-                let single_result = stack.pop().unwrap().value() != 0;
+                let single_result =
+                    stack.pop().ok_or(RustShadowError::StackUnderflow)?.value() != 0;
                 satisfied = satisfied && single_result;
             }
 
             stack.push(BFieldElement::new(satisfied as u64));
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/list/higher_order/all.rs
+++ b/tasm-lib/src/list/higher_order/all.rs
@@ -235,13 +235,13 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         let inner_function = InnerFunction::BasicSnippet(Box::new(TestHashXFieldElementLsb));
         ShadowedFunction::new(All::new(inner_function)).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn all_lt_test() {
         const TWO_POW_31: u64 = 1u64 << 31;
         let rawcode = RawCode::new(
@@ -296,7 +296,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_with_raw_function_lsb_on_bfe() {
         let rawcode = RawCode::new(
             triton_asm!(
@@ -316,7 +316,7 @@ mod tests {
         ShadowedFunction::new(snippet).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_with_raw_function_eq_42() {
         let raw_code = RawCode::new(
             triton_asm!(
@@ -332,7 +332,7 @@ mod tests {
         ShadowedFunction::new(snippet).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_with_raw_function_lsb_on_xfe() {
         let rawcode = RawCode::new(
             triton_asm!(
@@ -422,7 +422,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         let inner_function = InnerFunction::BasicSnippet(Box::new(TestHashXFieldElementLsb));
         ShadowedFunction::new(All::new(inner_function)).bench();

--- a/tasm-lib/src/list/higher_order/filter.rs
+++ b/tasm-lib/src/list/higher_order/filter.rs
@@ -165,33 +165,33 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
+        ) -> Result<(), RustShadowError> {
             let input_type = self.f.domain();
 
             let element_size = self.f.domain().stack_size();
             let safety_offset = LIST_METADATA_SIZE;
 
-            let list_pointer = stack.pop().unwrap();
+            let list_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
 
             // get list length
-            let len = rust_shadowing_helper_functions::list::list_get_length(list_pointer, memory);
+            let len = rust_shadowing_helper_functions::list::list_get_length(list_pointer, memory)?;
 
             let get_element = rust_shadowing_helper_functions::list::list_get;
 
-            New.rust_shadow(stack, memory);
-            let output_list = stack.pop().unwrap();
+            New.rust_shadow(stack, memory)?;
+            let output_list = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
 
             // set length
             stack.push(output_list);
             stack.push(bfe!(len));
-            SetLength.rust_shadow(stack, memory);
+            SetLength.rust_shadow(stack, memory)?;
             stack.pop();
 
             // forall elements, read + map + maybe copy
             let mut output_index = 0;
             for i in 0..len {
                 // read
-                let mut input_item = get_element(list_pointer, i, memory, input_type.stack_size());
+                let mut input_item = get_element(list_pointer, i, memory, input_type.stack_size())?;
 
                 // put on stack
                 while let Some(element) = input_item.pop() {
@@ -200,14 +200,14 @@ mod tests {
 
                 self.f.apply(stack, memory);
 
-                let satisfied = stack.pop().unwrap().value() != 0;
+                let satisfied = stack.pop().ok_or(RustShadowError::StackUnderflow)?.value() != 0;
 
                 // maybe copy
                 if satisfied {
                     stack.push(list_pointer + bfe!(safety_offset + i * element_size)); // read source
                     stack.push(output_list + bfe!(safety_offset + output_index * element_size)); // write dest
                     stack.push(bfe!(element_size)); // number of words
-                    MemCpy.rust_shadow(stack, memory);
+                    MemCpy.rust_shadow(stack, memory)?;
                     output_index += 1;
                 }
             }
@@ -215,7 +215,9 @@ mod tests {
             // set length
             stack.push(output_list);
             stack.push(bfe!(output_index));
-            SetLength.rust_shadow(stack, memory);
+            SetLength.rust_shadow(stack, memory)?;
+
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/list/higher_order/filter.rs
+++ b/tasm-lib/src/list/higher_order/filter.rs
@@ -323,7 +323,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_with_raw_function_lsb_on_bfe() {
         let rawcode = RawCode::new(
             triton_asm!(
@@ -345,7 +345,7 @@ mod tests {
         .test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_with_raw_function_lsb_on_xfe() {
         let rawcode = RawCode::new(
             triton_asm!(
@@ -374,7 +374,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(Filter {
             f: InnerFunction::BasicSnippet(Box::new(TestHashXFieldElementLsb)),

--- a/tasm-lib/src/list/higher_order/inner_function.rs
+++ b/tasm-lib/src/list/higher_order/inner_function.rs
@@ -222,8 +222,9 @@ impl InnerFunction {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_prelude::test;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn breakpoint_does_not_influence_raw_code_inlining() {
         let raw_code = RawCode {
             function: triton_asm! { my_label: return break },
@@ -234,7 +235,7 @@ mod tests {
         assert_eq!(triton_asm!(), inlined_code);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn type_hints_do_not_influence_raw_code_inlining() {
         let raw_code = RawCode {
             function: triton_asm! { my_label: hint a = stack[0] hint b = stack[1] return },
@@ -245,7 +246,7 @@ mod tests {
         assert_eq!(triton_asm!(), inlined_code);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn allow_raw_code_with_recurse_or_return_instruction() {
         let raw_code = triton_asm!(
             please_help_me:

--- a/tasm-lib/src/list/higher_order/map.rs
+++ b/tasm-lib/src/list/higher_order/map.rs
@@ -609,7 +609,7 @@ mod tests {
         ShadowedFunction::new(ChainMap::<15>::new(f())).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_with_raw_function_identity_on_bfe() {
         let f = || {
             InnerFunction::RawCode(RawCode::new(
@@ -621,7 +621,7 @@ mod tests {
         test_chain_map_with_different_num_input_lists(f);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_with_raw_function_bfe_lift() {
         let f = || {
             InnerFunction::RawCode(RawCode::new(
@@ -633,7 +633,7 @@ mod tests {
         test_chain_map_with_different_num_input_lists(f);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_with_raw_function_xfe_get_coeff_0() {
         let f = || {
             InnerFunction::RawCode(RawCode::new(
@@ -645,7 +645,7 @@ mod tests {
         test_chain_map_with_different_num_input_lists(f);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_with_raw_function_square_on_bfe() {
         let f = || {
             InnerFunction::RawCode(RawCode::new(
@@ -657,7 +657,7 @@ mod tests {
         test_chain_map_with_different_num_input_lists(f);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_with_raw_function_square_plus_n_on_bfe() {
         // Inner function calculates `|x| -> x*x + n`, where `x` is the list element,
         // and `n` is the same value for all elements.
@@ -681,7 +681,7 @@ mod tests {
         test_case::<10>();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_with_raw_function_square_on_xfe() {
         let f = || {
             InnerFunction::RawCode(RawCode::new(
@@ -693,7 +693,7 @@ mod tests {
         test_chain_map_with_different_num_input_lists(f);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_with_raw_function_xfe_to_digest() {
         let f = || {
             InnerFunction::RawCode(RawCode::new(
@@ -705,7 +705,7 @@ mod tests {
         test_chain_map_with_different_num_input_lists(f);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_with_raw_function_digest_to_xfe() {
         let f = || {
             InnerFunction::RawCode(RawCode::new(
@@ -717,7 +717,7 @@ mod tests {
         test_chain_map_with_different_num_input_lists(f);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_with_raw_function_square_on_xfe_plus_another_xfe() {
         fn test_case<const N: usize>() {
             let offset = ChainMap::<{ N }>::NUM_INTERNAL_REGISTERS;
@@ -747,7 +747,7 @@ mod tests {
         test_case::<7>();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_u32_list_to_unit_list() {
         let f = || {
             InnerFunction::RawCode(RawCode::new(
@@ -759,7 +759,7 @@ mod tests {
         test_chain_map_with_different_num_input_lists(f);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_u32_list_to_u64_list() {
         let f = || {
             InnerFunction::RawCode(RawCode::new(
@@ -771,7 +771,7 @@ mod tests {
         test_chain_map_with_different_num_input_lists(f);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_u32_list_to_u128_list_plus_x() {
         // this code only works with 1 input list
         let raw_code = InnerFunction::RawCode(u32_to_u128_add_another_u128());
@@ -785,7 +785,7 @@ mod tests {
         );
     }
 
-    #[proptest(cases = 10)]
+    #[macro_rules_attr::apply(proptest(cases = 10))]
     fn num_internal_registers_is_correct(#[strategy(arb())] guard: BFieldElement) {
         fn test_case<const N: usize>(guard: BFieldElement) {
             let offset = ChainMap::<{ N }>::NUM_INTERNAL_REGISTERS;
@@ -817,7 +817,7 @@ mod tests {
         test_case::<12>(guard);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn mapping_over_dynamic_length_items_works() {
         let f = || {
             let list_type = DataType::List(Box::new(DataType::Bfe));
@@ -832,7 +832,7 @@ mod tests {
         test_chain_map_with_different_num_input_lists(f);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn mapping_over_list_of_lists_writing_their_lengths_works() {
         let f = || {
             let list_type = DataType::List(Box::new(DataType::Bfe));
@@ -856,13 +856,13 @@ mod benches {
     use crate::list::higher_order::inner_function::RawCode;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn map_benchmark() {
         let f = InnerFunction::BasicSnippet(Box::new(TestHashXFieldElement));
         ShadowedFunction::new(Map::new(f)).bench();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn map_with_dyn_items_benchmark() {
         let list_type = DataType::List(Box::new(DataType::Bfe));
         let f = InnerFunction::RawCode(RawCode::new(

--- a/tasm-lib/src/list/higher_order/map.rs
+++ b/tasm-lib/src/list/higher_order/map.rs
@@ -469,16 +469,16 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
+        ) -> Result<(), RustShadowError> {
             let input_type = self.f.domain();
             let output_type = self.f.range();
 
-            New.rust_shadow(stack, memory);
-            let output_list_pointer = stack.pop().unwrap();
+            New.rust_shadow(stack, memory)?;
+            let output_list_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
 
-            let input_list_pointers = (0..NUM_INPUT_LISTS)
-                .map(|_| stack.pop().unwrap())
-                .collect_vec();
+            let input_list_pointers: Vec<_> = (0..NUM_INPUT_LISTS)
+                .map(|_| stack.pop().ok_or(RustShadowError::StackUnderflow))
+                .try_collect()?;
 
             // the inner function _must not_ rely on these elements
             let buffer = (0..Self::NUM_INTERNAL_REGISTERS).map(|_| rand::random::<BFieldElement>());
@@ -486,14 +486,15 @@ mod tests {
 
             let mut total_output_len = 0;
             for input_list_pointer in input_list_pointers {
-                let input_list_len = list_get_length(input_list_pointer, memory);
-                let output_list_len = list_get_length(output_list_pointer, memory);
+                let input_list_len = list_get_length(input_list_pointer, memory)?;
+                let output_list_len = list_get_length(output_list_pointer, memory)?;
                 let new_output_list_len = output_list_len + input_list_len;
                 list_set_length(output_list_pointer, new_output_list_len, memory);
 
                 for i in (0..input_list_len).rev() {
                     if input_type.static_length().is_some() {
-                        let elem = list_get(input_list_pointer, i, memory, input_type.stack_size());
+                        let elem =
+                            list_get(input_list_pointer, i, memory, input_type.stack_size())?;
                         stack.extend(elem.into_iter().rev());
                     } else {
                         let (len, ptr) = list_pointer_to_elem_pointer(
@@ -501,15 +502,15 @@ mod tests {
                             i,
                             memory,
                             &input_type,
-                        );
+                        )?;
                         stack.push(ptr);
                         stack.push(bfe!(len));
                     };
                     self.f.apply(stack, memory);
-                    let elem = (0..output_type.stack_size())
-                        .map(|_| stack.pop().unwrap())
-                        .collect();
-                    list_set(output_list_pointer, total_output_len + i, elem, memory);
+                    let elem: Vec<_> = (0..output_type.stack_size())
+                        .map(|_| stack.pop().ok_or(RustShadowError::StackUnderflow))
+                        .try_collect()?;
+                    list_set(output_list_pointer, total_output_len + i, elem, memory)?;
                 }
 
                 total_output_len += input_list_len;
@@ -520,6 +521,7 @@ mod tests {
             }
 
             stack.push(output_list_pointer);
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/list/higher_order/zip.rs
+++ b/tasm-lib/src/list/higher_order/zip.rs
@@ -13,6 +13,7 @@ use crate::prelude::*;
 use crate::rust_shadowing_helper_functions::list::untyped_insert_random_list;
 use crate::snippet_bencher::BenchmarkCase;
 use crate::traits::function::*;
+use crate::traits::rust_shadow::RustShadowError;
 
 /// Zips two lists of equal length, returning a new list of pairs of elements.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -214,16 +215,18 @@ impl Function for Zip {
         &self,
         stack: &mut Vec<BFieldElement>,
         memory: &mut HashMap<BFieldElement, BFieldElement>,
-    ) {
+    ) -> Result<(), RustShadowError> {
         use crate::rust_shadowing_helper_functions::dyn_malloc;
         use crate::rust_shadowing_helper_functions::list;
 
-        let right_pointer = stack.pop().unwrap();
-        let left_pointer = stack.pop().unwrap();
+        let right_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+        let left_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
 
-        let left_length = list::list_get_length(left_pointer, memory);
-        let right_length = list::list_get_length(right_pointer, memory);
-        assert_eq!(left_length, right_length);
+        let left_length = list::list_get_length(left_pointer, memory)?;
+        let right_length = list::list_get_length(right_pointer, memory)?;
+        if left_length != right_length {
+            return Err(RustShadowError::Other);
+        }
         let len = left_length;
 
         let output_pointer = dyn_malloc::dynamic_allocator(memory);
@@ -231,14 +234,16 @@ impl Function for Zip {
         list::list_set_length(output_pointer, len, memory);
 
         for i in 0..len {
-            let left_item = list::list_get(left_pointer, i, memory, self.left_type.stack_size());
-            let right_item = list::list_get(right_pointer, i, memory, self.right_type.stack_size());
+            let left_item = list::list_get(left_pointer, i, memory, self.left_type.stack_size())?;
+            let right_item =
+                list::list_get(right_pointer, i, memory, self.right_type.stack_size())?;
 
             let pair = right_item.into_iter().chain(left_item).collect_vec();
-            list::list_set(output_pointer, i, pair, memory);
+            list::list_set(output_pointer, i, pair, memory)?;
         }
 
         stack.push(output_pointer);
+        Ok(())
     }
 
     fn pseudorandom_initial_state(
@@ -310,13 +315,13 @@ mod tests {
         let right_pointer = bfe!(1_u64 << 60); // far enough
 
         let mut ram = HashMap::default();
-        write_list_to_ram(&mut ram, left_pointer, &left_list);
-        write_list_to_ram(&mut ram, right_pointer, &right_list);
+        write_list_to_ram(&mut ram, left_pointer, &left_list)?;
+        write_list_to_ram(&mut ram, right_pointer, &right_list)?;
 
         let mut stack = [empty_stack(), vec![left_pointer, right_pointer]].concat();
 
         let zip = Zip::new(DataType::U32, DataType::Xfe);
-        zip.rust_shadow(&mut stack, &mut ram);
+        zip.rust_shadow(&mut stack, &mut ram).unwrap();
         let output_list_pointer = stack.pop().unwrap();
         let tasm_zipped = *Vec::decode_from_memory(&ram, output_list_pointer).unwrap();
 
@@ -328,11 +333,13 @@ mod tests {
         ram: &mut HashMap<BFieldElement, BFieldElement>,
         list_pointer: BFieldElement,
         list: &[T],
-    ) {
+    ) -> Result<(), RustShadowError> {
         list::list_new(list_pointer, ram);
         for &item in list {
-            list::list_push(list_pointer, item.encode(), ram);
+            list::list_push(list_pointer, item.encode(), ram)?;
         }
+
+        Ok(())
     }
 }
 

--- a/tasm-lib/src/list/higher_order/zip.rs
+++ b/tasm-lib/src/list/higher_order/zip.rs
@@ -285,12 +285,12 @@ mod tests {
     use crate::rust_shadowing_helper_functions::list;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn prop_test_xfe_digest() {
         ShadowedFunction::new(Zip::new(DataType::Xfe, DataType::Digest)).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn list_prop_test_more_types() {
         ShadowedFunction::new(Zip::new(DataType::Bfe, DataType::Bfe)).test();
         ShadowedFunction::new(Zip::new(DataType::U64, DataType::U32)).test();
@@ -301,7 +301,7 @@ mod tests {
         ShadowedFunction::new(Zip::new(DataType::Digest, DataType::Digest)).test();
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn zipping_u32s_with_x_field_elements_correspond_to_bfieldcodec(
         left_list: Vec<u32>,
         #[strategy(vec(arb(), #left_list.len()))] right_list: Vec<XFieldElement>,
@@ -341,7 +341,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(Zip::new(DataType::Xfe, DataType::Digest)).bench();
     }

--- a/tasm-lib/src/list/horner_evaluation_dynamic_length.rs
+++ b/tasm-lib/src/list/horner_evaluation_dynamic_length.rs
@@ -129,20 +129,22 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let x0 = stack.pop().unwrap();
-            let x1 = stack.pop().unwrap();
-            let x2 = stack.pop().unwrap();
+        ) -> Result<(), RustShadowError> {
+            let x0 = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let x1 = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let x2 = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
             let x = XFieldElement::new([x0, x1, x2]);
 
-            let address = stack.pop().unwrap();
-            let coefficients = *Vec::<XFieldElement>::decode_from_memory(memory, address).unwrap();
+            let address = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let coefficients = *Vec::<XFieldElement>::decode_from_memory(memory, address)
+                .map_err(|_| RustShadowError::DecodingError)?;
             let polynomial = Polynomial::new(coefficients);
 
             let value = polynomial.evaluate_in_same_field(x);
             stack.push(value.coefficients[2]);
             stack.push(value.coefficients[1]);
             stack.push(value.coefficients[0]);
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/list/horner_evaluation_dynamic_length.rs
+++ b/tasm-lib/src/list/horner_evaluation_dynamic_length.rs
@@ -182,7 +182,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test() {
         for _ in 0..10 {
             ShadowedFunction::new(HornerEvaluationDynamicLength).test();
@@ -195,7 +195,7 @@ mod bench {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(HornerEvaluationDynamicLength).bench();
     }

--- a/tasm-lib/src/list/length.rs
+++ b/tasm-lib/src/list/length.rs
@@ -94,7 +94,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedAccessor::new(Length).test();
     }
@@ -105,7 +105,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn length_long_benchmark() {
         ShadowedAccessor::new(Length).bench();
     }

--- a/tasm-lib/src/list/length.rs
+++ b/tasm-lib/src/list/length.rs
@@ -71,10 +71,12 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let list_ptr = stack.pop().unwrap();
-            let list_length = memory[&list_ptr];
+        ) -> Result<(), RustShadowError> {
+            let list_ptr = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let list_length = *memory.get(&list_ptr).ok_or(RustShadowError::Other)?;
             stack.push(list_length);
+
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/list/multiset_equality_digests.rs
+++ b/tasm-lib/src/list/multiset_equality_digests.rs
@@ -240,22 +240,21 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let list_b_pointer = stack.pop().unwrap();
-            let list_a_pointer = stack.pop().unwrap();
+        ) -> Result<(), RustShadowError> {
+            let list_b_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let list_a_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
 
-            let a: Vec<[BFieldElement; Digest::LEN]> =
-                load_list_with_copy_elements(list_a_pointer, memory);
+            let a = load_list_with_copy_elements::<{ Digest::LEN }>(list_a_pointer, memory)?;
             let mut a = a.into_iter().map(Digest::new).collect_vec();
             a.sort_unstable();
-            let b: Vec<[BFieldElement; Digest::LEN]> =
-                load_list_with_copy_elements(list_b_pointer, memory);
+            let b = load_list_with_copy_elements::<{ Digest::LEN }>(list_b_pointer, memory)?;
             let mut b = b.into_iter().map(Digest::new).collect_vec();
             b.sort_unstable();
 
             // equate and push result to stack
             let result = a == b;
             stack.push(BFieldElement::new(result as u64));
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/list/multiset_equality_digests.rs
+++ b/tasm-lib/src/list/multiset_equality_digests.rs
@@ -403,7 +403,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedFunction::new(MultisetEqualityDigests).test();
     }
@@ -414,7 +414,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(MultisetEqualityDigests).bench();
     }

--- a/tasm-lib/src/list/multiset_equality_u64s.rs
+++ b/tasm-lib/src/list/multiset_equality_u64s.rs
@@ -261,7 +261,7 @@ mod tests {
     use crate::test_helpers::test_rust_equivalence_given_complete_state;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn returns_true_on_multiset_equality() {
         let snippet = MultisetEqualityU64s;
         let return_value_is_true = [
@@ -289,7 +289,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn returns_false_on_multiset_inequality() {
         let snippet = MultisetEqualityU64s;
         let return_value_is_false = [
@@ -317,7 +317,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn multiset_equality_u64s_pbt() {
         ShadowedFunction::new(MultisetEqualityU64s).test()
     }
@@ -601,7 +601,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(MultisetEqualityU64s).bench()
     }

--- a/tasm-lib/src/list/multiset_equality_u64s.rs
+++ b/tasm-lib/src/list/multiset_equality_u64s.rs
@@ -327,16 +327,16 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let list_b_pointer = stack.pop().unwrap();
-            let list_a_pointer = stack.pop().unwrap();
+        ) -> Result<(), RustShadowError> {
+            let list_b_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let list_a_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
 
-            let a: Vec<[BFieldElement; 2]> = load_list_with_copy_elements(list_a_pointer, memory);
-            let b: Vec<[BFieldElement; 2]> = load_list_with_copy_elements(list_b_pointer, memory);
+            let a = load_list_with_copy_elements::<2>(list_a_pointer, memory)?;
+            let b = load_list_with_copy_elements::<2>(list_b_pointer, memory)?;
 
             if a.len() != b.len() {
                 stack.push(BFieldElement::zero());
-                return;
+                return Ok(());
             }
 
             let len = a.len();
@@ -350,15 +350,15 @@ mod tests {
 
             // compute running products
             let mut running_product_a = XFieldElement::one();
-            for i in 0..len as u64 {
-                let u64_elem = list_get(list_a_pointer, i as usize, memory, U64_STACK_SIZE);
+            for i in 0..len {
+                let u64_elem = list_get(list_a_pointer, i, memory, U64_STACK_SIZE)?;
                 let m = XFieldElement::new([u64_elem[0], u64_elem[1], BFieldElement::zero()]);
                 let factor = m - indeterminate;
                 running_product_a *= factor;
             }
             let mut running_product_b = XFieldElement::one();
-            for i in 0..len as u64 {
-                let u64_elem = list_get(list_b_pointer, i as usize, memory, U64_STACK_SIZE);
+            for i in 0..len {
+                let u64_elem = list_get(list_b_pointer, i, memory, U64_STACK_SIZE)?;
                 let m = XFieldElement::new([u64_elem[0], u64_elem[1], BFieldElement::zero()]);
                 let factor = m - indeterminate;
                 running_product_b *= factor;
@@ -370,8 +370,9 @@ mod tests {
                 STATIC_MEMORY_FIRST_ADDRESS - bfe!(EXTENSION_DEGREE as u64 - 1),
                 &running_product_a,
             );
+            stack.push(bfe!((running_product_a == running_product_b) as u64));
 
-            stack.push(bfe!((running_product_a == running_product_b) as u64))
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/list/new.rs
+++ b/tasm-lib/src/list/new.rs
@@ -7,6 +7,7 @@ use crate::rust_shadowing_helper_functions::list::list_new;
 use crate::snippet_bencher::BenchmarkCase;
 use crate::traits::function::Function;
 use crate::traits::function::FunctionInitialState;
+use crate::traits::rust_shadow::RustShadowError;
 
 /// Creates a new list and returns a pointer to it.
 ///
@@ -57,11 +58,14 @@ impl Function for New {
         &self,
         stack: &mut Vec<BFieldElement>,
         memory: &mut HashMap<BFieldElement, BFieldElement>,
-    ) {
-        DynMalloc.rust_shadow(stack, memory);
+    ) -> Result<(), RustShadowError> {
+        DynMalloc.rust_shadow(stack, memory)?;
 
-        let &list_pointer = stack.last().unwrap();
+        let list_pointer = stack.last().copied();
+        let list_pointer = list_pointer.ok_or(RustShadowError::StackUnderflow)?;
         list_new(list_pointer, memory);
+
+        Ok(())
     }
 
     fn pseudorandom_initial_state(

--- a/tasm-lib/src/list/new.rs
+++ b/tasm-lib/src/list/new.rs
@@ -81,7 +81,7 @@ pub(crate) mod tests {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedFunction::new(New).test();
     }
@@ -92,7 +92,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(New).bench();
     }

--- a/tasm-lib/src/list/pop.rs
+++ b/tasm-lib/src/list/pop.rs
@@ -160,10 +160,11 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let list_address = stack.pop().unwrap();
-            let element = list_pop(list_address, memory, self.element_type.stack_size());
+        ) -> Result<(), RustShadowError> {
+            let list_address = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let element = list_pop(list_address, memory, self.element_type.stack_size())?;
             stack.extend(element.into_iter().rev());
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/list/pop.rs
+++ b/tasm-lib/src/list/pop.rs
@@ -179,7 +179,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         for ty in [
             DataType::Bool,
@@ -193,7 +193,7 @@ mod tests {
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn empty_list_crashes_vm(#[strategy(arb())] list_pointer: BFieldElement) {
         let pop = Pop::new(DataType::Digest);
         let initial_state = pop.set_up_initial_state(0, list_pointer);
@@ -205,7 +205,7 @@ mod tests {
     }
 
     /// See similar test for [`Get`] for an explanation.
-    #[proptest(cases = 100)]
+    #[macro_rules_attr::apply(proptest(cases = 100))]
     fn too_large_lists_crash_vm(
         #[strategy(1_u64 << 22..1 << 32)] list_length: u64,
         #[strategy(arb())] list_pointer: BFieldElement,
@@ -235,7 +235,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(Pop::new(DataType::Digest)).bench();
     }

--- a/tasm-lib/src/list/push.rs
+++ b/tasm-lib/src/list/push.rs
@@ -165,13 +165,14 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
+        ) -> Result<(), RustShadowError> {
             let element = (0..self.element_type.stack_size())
-                .map(|_| stack.pop().unwrap())
-                .collect();
-            let list_pointer = stack.pop().unwrap();
+                .map(|_| stack.pop().ok_or(RustShadowError::StackUnderflow))
+                .try_collect()?;
+            let list_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            list_push(list_pointer, element, memory)?;
 
-            list_push(list_pointer, element, memory);
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/list/push.rs
+++ b/tasm-lib/src/list/push.rs
@@ -187,7 +187,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         for ty in [
             DataType::Bool,
@@ -202,7 +202,7 @@ mod tests {
     }
 
     /// See similar test for [`Get`] for an explanation.
-    #[proptest(cases = 100)]
+    #[macro_rules_attr::apply(proptest(cases = 100))]
     fn too_large_lists_crash_vm(
         #[strategy(1_u64 << 29..1 << 32)] list_length: u64,
         #[strategy(arb())] list_pointer: BFieldElement,
@@ -233,7 +233,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(Push::new(DataType::Digest));
     }

--- a/tasm-lib/src/list/range.rs
+++ b/tasm-lib/src/list/range.rs
@@ -160,12 +160,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedFunction::new(Range).test();
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn invalid_range_crashes_vm(
         #[strategy(1_u32..)] minimum: u32,
         #[strategy(..#minimum)] supremum: u32,
@@ -183,7 +183,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(Range).bench();
     }

--- a/tasm-lib/src/list/range.rs
+++ b/tasm-lib/src/list/range.rs
@@ -122,16 +122,19 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let supremum = pop_encodable::<u32>(stack);
-            let minimum = pop_encodable::<u32>(stack);
-            assert!(minimum <= supremum);
+        ) -> Result<(), RustShadowError> {
+            let supremum = pop_encodable::<u32>(stack)?;
+            let minimum = pop_encodable::<u32>(stack)?;
+            if minimum > supremum {
+                return Err(RustShadowError::Other);
+            }
 
             let list_pointer = dynamic_allocator(memory);
             let list = (minimum..supremum).collect_vec();
             encode_to_memory(memory, list_pointer, &list);
 
             stack.push(list_pointer);
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/list/set.rs
+++ b/tasm-lib/src/list/set.rs
@@ -118,13 +118,11 @@ impl BasicSnippet for Set {
 #[cfg(test)]
 mod tests {
     use proptest::collection::vec;
-    use triton_vm::error::OpStackError::FailedU32Conversion;
 
     use super::*;
     use crate::U32_TO_USIZE_ERR;
     use crate::rust_shadowing_helper_functions::list::insert_random_list;
     use crate::rust_shadowing_helper_functions::list::list_set;
-    use crate::test_helpers::negative_test;
     use crate::test_prelude::*;
 
     impl Set {
@@ -176,7 +174,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         for ty in [
             DataType::Bool,
@@ -190,10 +188,10 @@ mod tests {
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn out_of_bounds_access_crashes_vm(
         #[strategy(0_usize..=1_000)] list_length: usize,
-        #[strategy(#list_length..1 << 32)] index: usize,
+        #[strategy(#list_length..=u32::MAX.try_into().unwrap())] index: usize,
         #[strategy(arb())] list_pointer: BFieldElement,
         #[strategy(vec(arb(), 1))] element: Vec<BFieldElement>,
     ) {
@@ -206,17 +204,21 @@ mod tests {
         );
     }
 
-    #[proptest]
+    // Don't test on `wasm32`: too large indices cannot be represented there.
+    #[test_strategy::proptest]
+    #[cfg(not(target_arch = "wasm32"))]
     fn too_large_indices_crash_vm(
         #[strategy(1_usize << 32..)] index: usize,
         #[strategy(arb())] list_pointer: BFieldElement,
         #[strategy(vec(arb(), 1))] element: Vec<BFieldElement>,
     ) {
+        use triton_vm::error::OpStackError::FailedU32Conversion;
+
         let list_length = 0;
         let set = Set::new(DataType::Bfe);
         let initial_state = set.set_up_initial_state(list_length, index, list_pointer, element);
         let expected_error = InstructionError::OpStackError(FailedU32Conversion(bfe!(index)));
-        negative_test(
+        crate::test_helpers::negative_test(
             &ShadowedFunction::new(set),
             initial_state.into(),
             &[expected_error],
@@ -224,7 +226,7 @@ mod tests {
     }
 
     /// See mirroring test for [`Get`] for an explanation.
-    #[proptest(cases = 100)]
+    #[macro_rules_attr::apply(proptest(cases = 100))]
     fn too_large_lists_crash_vm(
         #[strategy(1_u64 << 22..1 << 32)] list_length: u64,
         #[strategy((1 << 22) - 1..#list_length)] index: u64,
@@ -257,7 +259,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(Set::new(DataType::Digest)).bench();
     }

--- a/tasm-lib/src/list/set.rs
+++ b/tasm-lib/src/list/set.rs
@@ -150,15 +150,17 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let index = pop_encodable::<u32>(stack);
-            let list_pointer = stack.pop().unwrap();
+        ) -> Result<(), RustShadowError> {
+            let index = pop_encodable::<u32>(stack)?;
+            let list_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
             let element = (0..self.element_type.stack_size())
-                .map(|_| stack.pop().unwrap())
-                .collect_vec();
+                .map(|_| stack.pop().ok_or(RustShadowError::StackUnderflow))
+                .try_collect()?;
 
             let index = index.try_into().expect(U32_TO_USIZE_ERR);
-            list_set(list_pointer, index, element, memory);
+            list_set(list_pointer, index, element, memory)?;
+
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/list/set_length.rs
+++ b/tasm-lib/src/list/set_length.rs
@@ -103,7 +103,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedFunction::new(SetLength).test();
     }
@@ -114,7 +114,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(SetLength).bench();
     }

--- a/tasm-lib/src/list/set_length.rs
+++ b/tasm-lib/src/list/set_length.rs
@@ -76,13 +76,14 @@ pub(crate) mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let new_length = pop_encodable::<u32>(stack);
-            let list_address = stack.pop().unwrap();
+        ) -> Result<(), RustShadowError> {
+            let new_length = pop_encodable::<u32>(stack)?;
+            let list_address = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
             stack.push(list_address);
 
             let new_length = new_length.try_into().expect(U32_TO_USIZE_ERR);
             list_set_length(list_address, new_length, memory);
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/list/split_off.rs
+++ b/tasm-lib/src/list/split_off.rs
@@ -180,14 +180,17 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let at = pop_encodable::<u32>(stack)
+        ) -> Result<(), RustShadowError> {
+            let at = pop_encodable::<u32>(stack)?
                 .try_into()
                 .expect(U32_TO_USIZE_ERR);
-            let list_pointer = stack.pop().unwrap();
+            let list_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
 
             let mut list =
-                load_list_unstructured(self.element_type.stack_size(), list_pointer, memory);
+                load_list_unstructured(self.element_type.stack_size(), list_pointer, memory)?;
+            if at > list.len() {
+                return Err(RustShadowError::Other);
+            }
             let new_list = list.split_off(at);
 
             let new_list_pointer = dynamic_allocator(memory);
@@ -198,6 +201,7 @@ mod tests {
                 memory.insert(new_list_pointer + bfe!(offset), word);
             }
             stack.push(new_list_pointer);
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/list/split_off.rs
+++ b/tasm-lib/src/list/split_off.rs
@@ -220,7 +220,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         for element_type in [
             DataType::U32,
@@ -233,7 +233,7 @@ mod tests {
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn out_of_bounds_index_crashes_vm(
         #[strategy(Union::new(
             [DataType::U32, DataType::U64, DataType::Xfe, DataType::Digest].map(Just)
@@ -259,7 +259,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(SplitOff::new(DataType::Xfe)).bench();
     }

--- a/tasm-lib/src/list/sum_bfes.rs
+++ b/tasm-lib/src/list/sum_bfes.rs
@@ -165,13 +165,14 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
+        ) -> Result<(), RustShadowError> {
             const BFIELDELEMENT_SIZE: usize = 1;
-            let list_pointer = stack.pop().unwrap();
-            let list = load_list_with_copy_elements::<BFIELDELEMENT_SIZE>(list_pointer, memory);
+            let list_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let list = load_list_with_copy_elements::<BFIELDELEMENT_SIZE>(list_pointer, memory)?;
 
             let sum: BFieldElement = list.into_iter().map(|x| x[0]).sum();
             stack.push(sum);
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/list/sum_bfes.rs
+++ b/tasm-lib/src/list/sum_bfes.rs
@@ -214,7 +214,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn sum_bfes_pbt() {
         ShadowedFunction::new(SumOfBfes).test()
     }
@@ -225,7 +225,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(SumOfBfes).bench();
     }

--- a/tasm-lib/src/list/sum_xfes.rs
+++ b/tasm-lib/src/list/sum_xfes.rs
@@ -247,12 +247,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn sum_xfes_pbt() {
         ShadowedFunction::new(SumOfXfes).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn sum_xfes_unit_test() {
         let snippet = SumOfXfes;
         let input_list_2_long: Vec<XFieldElement> = vec![rand::random(), rand::random()];
@@ -304,7 +304,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(SumOfXfes).bench();
     }

--- a/tasm-lib/src/list/sum_xfes.rs
+++ b/tasm-lib/src/list/sum_xfes.rs
@@ -194,9 +194,9 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let list_pointer = stack.pop().unwrap();
-            let list = load_list_with_copy_elements::<EXTENSION_DEGREE>(list_pointer, memory);
+        ) -> Result<(), RustShadowError> {
+            let list_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let list = load_list_with_copy_elements::<EXTENSION_DEGREE>(list_pointer, memory)?;
 
             let sum: XFieldElement = list
                 .into_iter()
@@ -205,6 +205,7 @@ mod tests {
             for elem in sum.coefficients.into_iter().rev() {
                 stack.push(elem);
             }
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/list/swap_unchecked.rs
+++ b/tasm-lib/src/list/swap_unchecked.rs
@@ -167,16 +167,17 @@ mod tests {
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
             _: &NonDeterminism,
-        ) {
-            let b_index = stack.pop().unwrap().value() as usize;
-            let a_index = stack.pop().unwrap().value() as usize;
-            let list_pointer = stack.pop().unwrap();
+        ) -> Result<(), RustShadowError> {
+            let b_index = stack.pop().ok_or(RustShadowError::StackUnderflow)?.value() as usize;
+            let a_index = stack.pop().ok_or(RustShadowError::StackUnderflow)?.value() as usize;
+            let list_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
             let element_size = self.element_type.stack_size();
 
-            let a = list_get(list_pointer, a_index, memory, element_size);
-            let b = list_get(list_pointer, b_index, memory, element_size);
-            list_set(list_pointer, a_index, b, memory);
-            list_set(list_pointer, b_index, a, memory);
+            let a = list_get(list_pointer, a_index, memory, element_size)?;
+            let b = list_get(list_pointer, b_index, memory, element_size)?;
+            list_set(list_pointer, a_index, b, memory)?;
+            list_set(list_pointer, b_index, a, memory)?;
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/list/swap_unchecked.rs
+++ b/tasm-lib/src/list/swap_unchecked.rs
@@ -201,7 +201,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test() {
         for data_type in [
             DataType::Bfe,
@@ -234,7 +234,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedAlgorithm::new(SwapUnchecked::new(DataType::Xfe)).bench();
     }

--- a/tasm-lib/src/memory.rs
+++ b/tasm-lib/src/memory.rs
@@ -71,10 +71,7 @@ pub fn nd_memory_region() -> MemoryRegion {
     let size = LAST_ADDRESS_AVAILABLE_FOR_NON_DETERMINISTICALLY_ALLOCATED_MEMORY.value()
         - FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS.value();
 
-    MemoryRegion::new(
-        FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS,
-        size.try_into().unwrap(),
-    )
+    MemoryRegion::new(FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS, size)
 }
 
 /// Stores the encoding of the given object into memory at the given address, and returns
@@ -166,14 +163,11 @@ mod tests {
     use std::collections::HashMap;
 
     use num::Zero;
-    use proptest::prop_assert;
-    use proptest_arbitrary_interop::arb;
-    use test_strategy::proptest;
-    use triton_vm::prelude::BFieldElement;
 
     use super::*;
+    use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn last_populated_nd_memory_address_looks_sane() {
         let empty_memory = HashMap::default();
         assert!(last_populated_nd_memory_address(&empty_memory).is_none());
@@ -249,7 +243,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn first_free_nd_address_looks_sane() {
         for address in [0, 1, 100, u32::MAX - 3, u32::MAX - 3] {
             let one_populated_word: HashMap<_, _> = [(bfe!(address), BFieldElement::new(42))]
@@ -281,12 +275,12 @@ mod tests {
         assert!(first_free_nd_address(&last_word_populated).is_none());
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn all_addresses_between_0_and_u32max_belong_to_nd_memory(nd_address: u32) {
         prop_assert!(nd_memory_region().contains_address(bfe!(nd_address)));
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn addresses_outside_u32_range_do_not_belong_to_nd_memory(
         #[strategy(arb())]
         #[filter(#address.value() > u32::MAX as u64)]

--- a/tasm-lib/src/memory/dyn_malloc.rs
+++ b/tasm-lib/src/memory/dyn_malloc.rs
@@ -37,9 +37,7 @@ impl DynMalloc {
     pub fn memory_region() -> MemoryRegion {
         MemoryRegion::new(
             DYN_MALLOC_FIRST_ADDRESS,
-            (NUM_ALLOCATABLE_PAGES * DYN_MALLOC_PAGE_SIZE)
-                .try_into()
-                .unwrap(),
+            NUM_ALLOCATABLE_PAGES * DYN_MALLOC_PAGE_SIZE,
         )
     }
 }
@@ -190,17 +188,17 @@ pub mod tests {
     use crate::test_helpers::negative_test;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn expected_address_chosen_for_dyn_malloc() {
         assert_eq!(bfe!(-1), DYN_MALLOC_ADDRESS);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedFunction::new(DynMalloc).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn disallow_allocation_outside_of_region_unit_test() {
         fn negative_prop_disallow_allocation_outside_of_region(memory_page_index: BFieldElement) {
             let snippet = DynMalloc;
@@ -224,7 +222,7 @@ pub mod tests {
         negative_prop_disallow_allocation_outside_of_region(bfe!(u32::MAX));
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn disallow_allocation_if_page_counter_is_not_a_u32(
         #[strategy(arb())]
         #[filter(#address.value() > u64::from(u32::MAX))]
@@ -297,7 +295,7 @@ pub mod tests {
         }
     }
 
-    #[proptest(cases = 20)]
+    #[macro_rules_attr::apply(proptest(cases = 20))]
     fn dynamic_allocator_can_be_called_multiple_times(
         #[strategy(0_usize..1_000)] num_calls: usize,
     ) {
@@ -311,7 +309,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(DynMalloc).bench();
     }

--- a/tasm-lib/src/memory/dyn_malloc.rs
+++ b/tasm-lib/src/memory/dyn_malloc.rs
@@ -10,6 +10,7 @@ use crate::prelude::*;
 use crate::snippet_bencher::BenchmarkCase;
 use crate::traits::function::Function;
 use crate::traits::function::FunctionInitialState;
+use crate::traits::rust_shadow::RustShadowError;
 
 /// The location of the dynamic allocator state in memory.
 ///
@@ -102,17 +103,16 @@ impl Function for DynMalloc {
         &self,
         stack: &mut Vec<BFieldElement>,
         memory: &mut HashMap<BFieldElement, BFieldElement>,
-    ) {
+    ) -> Result<(), RustShadowError> {
         let mut page_idx = memory.get(&DYN_MALLOC_ADDRESS).copied().unwrap_or_default();
         if page_idx.is_zero() {
             page_idx = DYN_MALLOC_FIRST_PAGE.into();
         }
         let page_idx = page_idx;
 
-        assert!(
-            page_idx.value() < NUM_ALLOCATABLE_PAGES,
-            "All allocations must happen inside dyn malloc's region"
-        );
+        if page_idx.value() >= NUM_ALLOCATABLE_PAGES {
+            return Err(RustShadowError::Other);
+        }
 
         let next_page_idx = page_idx + bfe!(1);
 
@@ -120,6 +120,7 @@ impl Function for DynMalloc {
 
         let page_address = page_idx * BFieldElement::new(DYN_MALLOC_PAGE_SIZE);
         stack.push(page_address);
+        Ok(())
     }
 
     fn pseudorandom_initial_state(
@@ -280,10 +281,11 @@ pub mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
+        ) -> Result<(), RustShadowError> {
             for _ in 0..self.num_calls {
-                DynMalloc.rust_shadow(stack, memory);
+                DynMalloc.rust_shadow(stack, memory)?;
             }
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/memory/memcpy.rs
+++ b/tasm-lib/src/memory/memcpy.rs
@@ -156,12 +156,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedFunction::new(MemCpy).test();
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn exceeding_max_size_crashes_vm(#[strategy(DEFAULT_MAX_DYN_FIELD_SIZE..)] len: u32) {
         // actually filling memory with `len` random elements is a waste of time
         let mut stack = MemCpy.init_stack_for_isolated_run();
@@ -181,7 +181,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(MemCpy).bench();
     }

--- a/tasm-lib/src/memory/memcpy.rs
+++ b/tasm-lib/src/memory/memcpy.rs
@@ -117,11 +117,13 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let len = pop_encodable(stack);
-            let write_dest = stack.pop().unwrap();
-            let read_source = stack.pop().unwrap();
-            assert!(len < DEFAULT_MAX_DYN_FIELD_SIZE);
+        ) -> Result<(), RustShadowError> {
+            let len = pop_encodable(stack)?;
+            let write_dest = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let read_source = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            if len >= DEFAULT_MAX_DYN_FIELD_SIZE {
+                return Err(RustShadowError::Other);
+            }
 
             for i in 0..len {
                 let offset = bfe!(i);
@@ -129,6 +131,7 @@ mod tests {
                 let element = maybe_element.copied().unwrap_or_default();
                 memory.insert(write_dest + offset, element);
             }
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/mmr/bag_peaks.rs
+++ b/tasm-lib/src/mmr/bag_peaks.rs
@@ -226,7 +226,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedFunction::new(BagPeaks).test()
     }
@@ -237,7 +237,7 @@ mod benches {
     use super::BagPeaks;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(BagPeaks).bench();
     }

--- a/tasm-lib/src/mmr/bag_peaks.rs
+++ b/tasm-lib/src/mmr/bag_peaks.rs
@@ -181,27 +181,31 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let address = pop_encodable(stack);
-            let mmra = *MmrAccumulator::decode_from_memory(memory, address).unwrap();
+        ) -> Result<(), RustShadowError> {
+            let address = pop_encodable(stack)?;
+            let mmra = *MmrAccumulator::decode_from_memory(memory, address)
+                .map_err(|_| RustShadowError::DecodingError)?;
 
-            fn bag_peaks(peaks: &[Digest], leaf_count: u64) -> Digest {
+            fn bag_peaks(peaks: &[Digest], leaf_count: u64) -> Result<Digest, RustShadowError> {
                 // use `hash_10` over `hash` or `hash_varlen` to simplify hashing in Triton VM
                 let [lo_limb, hi_limb] = leaf_count.encode()[..] else {
-                    panic!("internal error: unknown encoding of type `u64`")
+                    return Err(RustShadowError::Other);
                 };
                 let padded_leaf_count = bfe_array![lo_limb, hi_limb, 0, 0, 0, 0, 0, 0, 0, 0];
                 let hashed_leaf_count = Digest::new(Tip5::hash_10(&padded_leaf_count));
 
-                peaks
+                let digest = peaks
                     .iter()
                     .rev()
-                    .fold(hashed_leaf_count, |acc, &peak| Tip5::hash_pair(peak, acc))
+                    .fold(hashed_leaf_count, |acc, &peak| Tip5::hash_pair(peak, acc));
+
+                Ok(digest)
             }
 
-            let bag = bag_peaks(&mmra.peaks(), mmra.num_leafs());
+            let bag = bag_peaks(&mmra.peaks(), mmra.num_leafs())?;
             println!("bag: {bag}");
             push_encodable(stack, &bag);
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/mmr/calculate_new_peaks_from_append.rs
+++ b/tasm-lib/src/mmr/calculate_new_peaks_from_append.rs
@@ -212,7 +212,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedFunction::new(CalculateNewPeaksFromAppend).test();
     }
@@ -223,7 +223,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn calculate_new_peaks_from_append_benchmark() {
         ShadowedFunction::new(CalculateNewPeaksFromAppend).bench();
     }

--- a/tasm-lib/src/mmr/calculate_new_peaks_from_append.rs
+++ b/tasm-lib/src/mmr/calculate_new_peaks_from_append.rs
@@ -150,21 +150,28 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let new_leaf = pop_encodable::<Digest>(stack);
-            let peaks_pointer = stack.pop().unwrap();
-            let old_num_leafs = pop_encodable::<u64>(stack);
-            let old_peaks = *Vec::decode_from_memory(memory, peaks_pointer).unwrap();
+        ) -> Result<(), RustShadowError> {
+            let new_leaf = pop_encodable::<Digest>(stack)?;
+            let peaks_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let old_num_leafs = pop_encodable::<u64>(stack)?;
+            let old_peaks = *Vec::decode_from_memory(memory, peaks_pointer)
+                .map_err(|_| RustShadowError::DecodingError)?;
 
             // Mimic all potential artifacts of the snippet.
             // This is _not_ shadowing the actual behavior, only intermediate results.
-            list_push(peaks_pointer, new_leaf.encode(), memory);
+            list_push(peaks_pointer, new_leaf.encode(), memory)?;
             let old_num_peaks = old_num_leafs.count_ones();
             for _ in 0..old_num_peaks {
-                let left = list_pop(peaks_pointer, memory, Digest::LEN);
-                let right = list_pop(peaks_pointer, memory, Digest::LEN);
-                let new = Tip5::hash_pair(right.try_into().unwrap(), left.try_into().unwrap());
-                list_push(peaks_pointer, new.encode(), memory);
+                let left = list_pop(peaks_pointer, memory, Digest::LEN)?;
+                let right = list_pop(peaks_pointer, memory, Digest::LEN)?;
+                let right: Digest = right
+                    .try_into()
+                    .map_err(|_| RustShadowError::DecodingError)?;
+                let left: Digest = left
+                    .try_into()
+                    .map_err(|_| RustShadowError::DecodingError)?;
+                let new = Tip5::hash_pair(right, left);
+                list_push(peaks_pointer, new.encode(), memory)?;
             }
 
             // actually shadow the snippet
@@ -176,6 +183,7 @@ mod tests {
             encode_to_memory(memory, auth_path_pointer, &proof.authentication_path);
             stack.push(peaks_pointer);
             stack.push(auth_path_pointer);
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/mmr/calculate_new_peaks_from_leaf_mutation.rs
+++ b/tasm-lib/src/mmr/calculate_new_peaks_from_leaf_mutation.rs
@@ -227,12 +227,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedFunction::new(MmrCalculateNewPeaksFromLeafMutationMtIndices).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn mmra_leaf_mutate_test_single() {
         let digest0 = Tip5::hash(&BFieldElement::new(4545));
         let digest1 = Tip5::hash(&BFieldElement::new(12345));
@@ -278,21 +278,21 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn mmra_leaf_mutate_test_many_leaf_sizes() {
         for leaf_count in 1..30 {
             mmra_leaf_mutate_test_n_leafs(leaf_count);
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn mmra_leaf_mutate_test_other_leaf_sizes() {
         for leaf_count in [127, 128] {
             mmra_leaf_mutate_test_n_leafs(leaf_count);
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn mmra_leaf_mutate_big() {
         for log_sizes in [15u64, 20, 25, 32, 35, 40, 45, 50, 55, 60, 62, 63] {
             println!("log_sizes = {log_sizes}");
@@ -314,7 +314,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn mmra_leaf_mutate_advanced() {
         for log_size in [31, 63] {
             println!("log_sizes = {log_size}");
@@ -412,7 +412,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(MmrCalculateNewPeaksFromLeafMutationMtIndices).bench();
     }

--- a/tasm-lib/src/mmr/calculate_new_peaks_from_leaf_mutation.rs
+++ b/tasm-lib/src/mmr/calculate_new_peaks_from_leaf_mutation.rs
@@ -178,15 +178,17 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let leaf_count = pop_encodable(stack);
-            let new_leaf = pop_encodable(stack);
-            let peaks_pointer = stack.pop().unwrap();
-            let leaf_index = pop_encodable(stack);
-            let auth_path_pointer = stack.pop().unwrap();
+        ) -> Result<(), RustShadowError> {
+            let leaf_count = pop_encodable(stack)?;
+            let new_leaf = pop_encodable(stack)?;
+            let peaks_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let leaf_index = pop_encodable(stack)?;
+            let auth_path_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
 
-            let peaks = *Vec::decode_from_memory(memory, peaks_pointer).unwrap();
-            let auth_path = *Vec::decode_from_memory(memory, auth_path_pointer).unwrap();
+            let peaks = *Vec::decode_from_memory(memory, peaks_pointer)
+                .map_err(|_| RustShadowError::DecodingError)?;
+            let auth_path = *Vec::decode_from_memory(memory, auth_path_pointer)
+                .map_err(|_| RustShadowError::DecodingError)?;
             let mmr_mp = MmrMembershipProof::new(auth_path);
             let new_peaks = mmr::shared_basic::calculate_new_peaks_from_leaf_mutation(
                 &peaks, leaf_count, new_leaf, leaf_index, &mmr_mp,
@@ -195,6 +197,7 @@ mod tests {
 
             stack.push(auth_path_pointer);
             push_encodable(stack, &leaf_index);
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/mmr/leaf_index_to_mt_index_and_peak_index.rs
+++ b/tasm-lib/src/mmr/leaf_index_to_mt_index_and_peak_index.rs
@@ -223,12 +223,12 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(MmrLeafIndexToMtIndexAndPeakIndex).test();
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn property_test(
         #[strategy(1_u64..)] num_leafs: u64,
         #[strategy(0_u64..#num_leafs)] leaf_index: u64,
@@ -236,7 +236,7 @@ pub(crate) mod tests {
         MmrLeafIndexToMtIndexAndPeakIndex.assert_expected_behavior(num_leafs, leaf_index);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn negative_property_test(num_leafs: u64, #[strategy(#num_leafs..)] leaf_index: u64) {
         let initial_stack =
             MmrLeafIndexToMtIndexAndPeakIndex.set_up_test_stack((num_leafs, leaf_index));
@@ -254,7 +254,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(MmrLeafIndexToMtIndexAndPeakIndex).bench();
     }

--- a/tasm-lib/src/mmr/leaf_index_to_mt_index_and_peak_index.rs
+++ b/tasm-lib/src/mmr/leaf_index_to_mt_index_and_peak_index.rs
@@ -151,7 +151,7 @@ pub(crate) mod tests {
             let initial_stack = self.set_up_test_stack((num_leafs, leaf_index));
 
             let mut expected_stack = initial_stack.clone();
-            self.rust_shadow(&mut expected_stack);
+            self.rust_shadow(&mut expected_stack).unwrap();
 
             test_rust_equivalence_given_complete_state(
                 &ShadowedClosure::new(Self),
@@ -167,14 +167,18 @@ pub(crate) mod tests {
     impl Closure for MmrLeafIndexToMtIndexAndPeakIndex {
         type Args = (u64, u64);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (num_leafs, leaf_index) = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (num_leafs, leaf_index) = pop_encodable::<Self::Args>(stack)?;
 
+            if leaf_index >= num_leafs {
+                return Err(RustShadowError::Other);
+            }
             let (mt_index, peak_index) =
                 leaf_index_to_mt_index_and_peak_index(leaf_index, num_leafs);
 
             push_encodable(stack, &mt_index);
             push_encodable(stack, &peak_index);
+            Ok(())
         }
 
         fn pseudorandom_args(

--- a/tasm-lib/src/mmr/verify_from_memory.rs
+++ b/tasm-lib/src/mmr/verify_from_memory.rs
@@ -213,13 +213,13 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedFunction::new(MmrVerifyFromMemory).test();
     }
 
     // This will crash the VM because leaf?index is not strictly less than leaf_count
-    #[test]
+    #[macro_rules_attr::apply(test)]
     #[should_panic]
     fn mmra_ap_verify_test_empty() {
         let digest0 = Tip5::hash(&BFieldElement::new(4545));
@@ -228,7 +228,7 @@ mod tests {
         prop_verify_from_memory(&mmr, digest0, leaf_index, vec![], false);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn mmra_ap_verify_test_one() {
         let digest0 = Tip5::hash(&BFieldElement::new(4545));
         let mut mmr = MmrAccumulator::new_from_leafs(vec![]);
@@ -237,7 +237,7 @@ mod tests {
         prop_verify_from_memory(&mmr, digest0, leaf_index, vec![], true);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn mmra_ap_verify_test_two() {
         let digest0 = Tip5::hash(&BFieldElement::new(123));
         let digest1 = Tip5::hash(&BFieldElement::new(456));
@@ -253,7 +253,7 @@ mod tests {
         prop_verify_from_memory(&mmr, digest1, leaf_index_1, vec![digest0], true);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn mmra_ap_verify_test_pbt() {
         let max_size = 19;
 
@@ -305,7 +305,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn mmra_ap_verify_many_leafs() {
         for init_leaf_count in [
             (1u64 << 40) + (1 << 21) + 510,
@@ -419,7 +419,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(MmrVerifyFromMemory).bench();
     }

--- a/tasm-lib/src/mmr/verify_from_memory.rs
+++ b/tasm-lib/src/mmr/verify_from_memory.rs
@@ -174,19 +174,22 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let auth_path_pointer = stack.pop().unwrap();
-            let leaf = pop_encodable(stack);
-            let leaf_index = pop_encodable(stack);
-            let leaf_count = pop_encodable(stack);
-            let peaks_pointer = stack.pop().unwrap();
+        ) -> Result<(), RustShadowError> {
+            let auth_path_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let leaf = pop_encodable(stack)?;
+            let leaf_index = pop_encodable(stack)?;
+            let leaf_count = pop_encodable(stack)?;
+            let peaks_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
 
-            let auth_path = *Vec::<Digest>::decode_from_memory(memory, auth_path_pointer).unwrap();
-            let peaks = *Vec::<Digest>::decode_from_memory(memory, peaks_pointer).unwrap();
+            let auth_path = *Vec::<Digest>::decode_from_memory(memory, auth_path_pointer)
+                .map_err(|_| RustShadowError::DecodingError)?;
+            let peaks = *Vec::<Digest>::decode_from_memory(memory, peaks_pointer)
+                .map_err(|_| RustShadowError::DecodingError)?;
 
             let proof = MmrMembershipProof::new(auth_path);
             let is_valid = proof.verify(leaf_index, leaf, &peaks, leaf_count);
             push_encodable(stack, &is_valid);
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/mmr/verify_from_secret_in_leaf_index_on_stack.rs
+++ b/tasm-lib/src/mmr/verify_from_secret_in_leaf_index_on_stack.rs
@@ -165,13 +165,14 @@ mod tests {
             nondeterminism: &NonDeterminism,
             _: &[BFieldElement],
             _: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
-            let leaf_index = pop_encodable(stack);
-            let leaf_count = pop_encodable(stack);
-            let leaf_digest = pop_encodable(stack);
-            let peaks_pointer = pop_encodable(stack);
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
+            let leaf_index = pop_encodable(stack)?;
+            let leaf_count = pop_encodable(stack)?;
+            let leaf_digest = pop_encodable(stack)?;
+            let peaks_pointer = pop_encodable(stack)?;
 
-            let peaks = Vec::<Digest>::decode_from_memory(memory, peaks_pointer).unwrap();
+            let peaks = Vec::<Digest>::decode_from_memory(memory, peaks_pointer)
+                .map_err(|_| RustShadowError::DecodingError)?;
 
             let (mut mt_index, _peak_index) =
                 leaf_index_to_mt_index_and_peak_index(leaf_index, leaf_count);
@@ -191,9 +192,7 @@ mod tests {
                 leaf_count,
             );
 
-            assert!(valid_mp, "MMR leaf must authenticate against peak");
-
-            vec![]
+            valid_mp.then(Vec::new).ok_or(RustShadowError::InvalidProof)
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/mmr/verify_from_secret_in_leaf_index_on_stack.rs
+++ b/tasm-lib/src/mmr/verify_from_secret_in_leaf_index_on_stack.rs
@@ -227,12 +227,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedProcedure::new(MmrVerifyFromSecretInLeafIndexOnStack).test();
     }
 
-    #[proptest(cases = 32)]
+    #[macro_rules_attr::apply(proptest(cases = 32))]
     fn negative_test_bad_leaf_index(
         #[strategy(0_u64..1 << 62)] leaf_count: u64,
         #[strategy(0_u64..#leaf_count)] real_leaf_index: u64,
@@ -278,7 +278,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedProcedure::new(MmrVerifyFromSecretInLeafIndexOnStack).bench();
     }

--- a/tasm-lib/src/mmr/verify_from_secret_in_secret_leaf_index.rs
+++ b/tasm-lib/src/mmr/verify_from_secret_in_secret_leaf_index.rs
@@ -116,14 +116,14 @@ mod tests {
     use crate::test_helpers::test_rust_equivalence_given_complete_state;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn prop() {
         for _ in 0..10 {
             ShadowedProcedure::new(MmrVerifyFromSecretInSecretLeafIndex).test();
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn mmra_ap_verify_test_one() {
         let digest0 = Tip5::hash(&BFieldElement::new(4545));
         let (mmra, _mps) = mmra_with_mps(1u64, vec![(0, digest0)]);
@@ -135,7 +135,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn mmra_ap_verify_test_two() {
         let digest0 = Tip5::hash(&BFieldElement::new(123));
         let digest1 = Tip5::hash(&BFieldElement::new(456));
@@ -160,7 +160,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn mmra_ap_verify_test_pbt() {
         let max_size = 19;
         let snippet = MmrVerifyFromSecretInSecretLeafIndex;
@@ -201,7 +201,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn mmra_ap_verify_many_leafs() {
         for init_leaf_count in [
             (1u64 << 40) + (1 << 21) + 510,
@@ -534,7 +534,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedProcedure::new(MmrVerifyFromSecretInSecretLeafIndex).bench();
     }

--- a/tasm-lib/src/mmr/verify_from_secret_in_secret_leaf_index.rs
+++ b/tasm-lib/src/mmr/verify_from_secret_in_secret_leaf_index.rs
@@ -275,17 +275,25 @@ mod tests {
             nondeterminism: &NonDeterminism,
             _public_input: &[BFieldElement],
             _sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
             let mut leaf_digest = [BFieldElement::new(0); Digest::LEN];
             for elem in leaf_digest.iter_mut() {
-                *elem = stack.pop().unwrap();
+                *elem = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
             }
 
             let leaf_digest = Digest::new(leaf_digest);
-            let leaf_count_lo: u32 = stack.pop().unwrap().try_into().unwrap();
-            let leaf_count_hi: u32 = stack.pop().unwrap().try_into().unwrap();
+            let leaf_count_lo: u32 = stack
+                .pop()
+                .ok_or(RustShadowError::StackUnderflow)?
+                .try_into()
+                .map_err(|_| RustShadowError::U64ToU32Error)?;
+            let leaf_count_hi: u32 = stack
+                .pop()
+                .ok_or(RustShadowError::StackUnderflow)?
+                .try_into()
+                .map_err(|_| RustShadowError::U64ToU32Error)?;
             let leaf_count: u64 = ((leaf_count_hi as u64) << 32) + leaf_count_lo as u64;
-            let peaks_pointer = stack.pop().unwrap();
+            let peaks_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
             let peaks_count: u64 = memory[&peaks_pointer].value();
             let mut peaks: Vec<Digest> = vec![];
             for i in 0..peaks_count {
@@ -294,17 +302,17 @@ mod tests {
                     i as usize,
                     memory,
                     Digest::LEN,
-                );
+                )?;
                 peaks.push(Digest::new(digest_innards.try_into().unwrap()));
             }
             let leaf_index_hi: u32 = nondeterminism.individual_tokens[0]
                 .value()
                 .try_into()
-                .unwrap();
+                .map_err(|_| RustShadowError::U64ToU32Error)?;
             let leaf_index_lo: u32 = nondeterminism.individual_tokens[1]
                 .value()
                 .try_into()
-                .unwrap();
+                .map_err(|_| RustShadowError::U64ToU32Error)?;
             let leaf_index: u64 = ((leaf_index_hi as u64) << 32) + leaf_index_lo as u64;
             let (mut mt_index, _peak_index) =
                 leaf_index_to_mt_index_and_peak_index(leaf_index, leaf_count);
@@ -324,9 +332,7 @@ mod tests {
                 leaf_count,
             );
 
-            assert!(valid_mp, "MMR leaf not authenticated");
-
-            vec![]
+            valid_mp.then(Vec::new).ok_or(RustShadowError::InvalidProof)
         }
 
         fn pseudorandom_initial_state(
@@ -516,7 +522,8 @@ mod tests {
                     peaks_pointer,
                     peak.values().to_vec(),
                     &mut memory,
-                );
+                )
+                .unwrap();
             }
 
             let nondeterminism = NonDeterminism::default().with_ram(memory);

--- a/tasm-lib/src/mmr/verify_mmr_successor.rs
+++ b/tasm-lib/src/mmr/verify_mmr_successor.rs
@@ -610,12 +610,12 @@ mod tests {
         initial_states
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn unit() {
         ShadowedReadOnlyAlgorithm::new(VerifyMmrSuccessor).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn verify_mmr_successor_negative_test() {
         let all_error_ids = [
             VerifyMmrSuccessor::OLD_HAS_MORE_LEAFS_THAN_NEW_ERROR_ID,
@@ -641,7 +641,7 @@ mod bench {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedReadOnlyAlgorithm::new(VerifyMmrSuccessor).bench();
     }

--- a/tasm-lib/src/mmr/verify_mmr_successor.rs
+++ b/tasm-lib/src/mmr/verify_mmr_successor.rs
@@ -426,16 +426,23 @@ mod tests {
             memory: &HashMap<BFieldElement, BFieldElement>,
             nd_tokens: VecDeque<BFieldElement>,
             nd_digests: VecDeque<Digest>,
-        ) {
-            let new_mmr_pointer = stack.pop().unwrap();
-            let old_mmr_pointer = stack.pop().unwrap();
+        ) -> Result<(), RustShadowError> {
+            let new_mmr_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let old_mmr_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
 
-            let new_mmr = *MmrAccumulator::decode_from_memory(memory, new_mmr_pointer).unwrap();
-            let old_mmr = *MmrAccumulator::decode_from_memory(memory, old_mmr_pointer).unwrap();
+            let new_mmr = *MmrAccumulator::decode_from_memory(memory, new_mmr_pointer)
+                .map_err(|_| RustShadowError::DecodingError)?;
+            let old_mmr = *MmrAccumulator::decode_from_memory(memory, old_mmr_pointer)
+                .map_err(|_| RustShadowError::DecodingError)?;
 
             // figure out the length of the authentication path
-            let num_new_leafs = new_mmr.num_leafs() - old_mmr.num_leafs();
-            let new_dummy_leafs = vec![Digest::default(); num_new_leafs.try_into().unwrap()];
+            let num_new_leafs = new_mmr
+                .num_leafs()
+                .checked_sub(old_mmr.num_leafs())
+                .ok_or(RustShadowError::ArithmeticOverflow)?
+                .try_into()
+                .map_err(|_| RustShadowError::U64ToUsizeError)?;
+            let new_dummy_leafs = vec![Digest::default(); num_new_leafs];
             let dummy_proof = MmrSuccessorProof::new_from_batch_append(&old_mmr, &new_dummy_leafs);
             let auth_path_len = dummy_proof.paths.len();
 
@@ -443,7 +450,11 @@ mod tests {
             let mut path = vec![];
             if auth_path_len > 0 {
                 let first_element = (0..Digest::LEN).rev().map(|i| nd_tokens[i]).collect_vec();
-                path.push(Digest::new(first_element.try_into().unwrap()));
+                path.push(Digest::new(
+                    first_element
+                        .try_into()
+                        .map_err(|_| RustShadowError::Other)?,
+                ));
             }
 
             // grab remaining path elements from nd digests
@@ -451,7 +462,10 @@ mod tests {
                 path.extend((0..auth_path_len - 1).map(|i| nd_digests[i]));
             }
 
-            assert!(MmrSuccessorProof { paths: path }.verify(&old_mmr, &new_mmr));
+            MmrSuccessorProof { paths: path }
+                .verify(&old_mmr, &new_mmr)
+                .then_some(())
+                .ok_or(RustShadowError::InvalidProof)
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/neptune/mutator_set/commit.rs
+++ b/tasm-lib/src/neptune/mutator_set/commit.rs
@@ -77,7 +77,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(Commit).test();
     }
@@ -88,7 +88,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(Commit).bench();
     }

--- a/tasm-lib/src/neptune/mutator_set/commit.rs
+++ b/tasm-lib/src/neptune/mutator_set/commit.rs
@@ -65,11 +65,12 @@ mod tests {
     impl Closure for Commit {
         type Args = (Digest, Digest, Digest);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (receiver_digest, sender_randomness, item) = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (receiver_digest, sender_randomness, item) = pop_encodable::<Self::Args>(stack)?;
             let commitment =
                 Tip5::hash_pair(Tip5::hash_pair(item, sender_randomness), receiver_digest);
             push_encodable(stack, &commitment);
+            Ok(())
         }
 
         fn pseudorandom_args(&self, seed: [u8; 32], _: Option<BenchmarkCase>) -> Self::Args {

--- a/tasm-lib/src/neptune/mutator_set/get_swbf_indices.rs
+++ b/tasm-lib/src/neptune/mutator_set/get_swbf_indices.rs
@@ -195,11 +195,11 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let item = pop_encodable::<Digest>(stack);
-            let sender_randomness = pop_encodable::<Digest>(stack);
-            let receiver_preimage = pop_encodable::<Digest>(stack);
-            let aocl_leaf_index = pop_encodable::<u64>(stack);
+        ) -> Result<(), RustShadowError> {
+            let item = pop_encodable::<Digest>(stack)?;
+            let sender_randomness = pop_encodable::<Digest>(stack)?;
+            let receiver_preimage = pop_encodable::<Digest>(stack)?;
+            let aocl_leaf_index = pop_encodable::<u64>(stack)?;
 
             let mut sponge_seed = [item, sender_randomness, receiver_preimage]
                 .map(|d| d.values())
@@ -215,7 +215,7 @@ mod tests {
                 if squeezed_elements.is_empty() {
                     squeezed_elements = sponge.squeeze().into_iter().rev().collect_vec();
                 }
-                let element = squeezed_elements.pop().unwrap();
+                let element = squeezed_elements.pop().ok_or(RustShadowError::Other)?;
                 if element != BFieldElement::new(BFieldElement::MAX) {
                     u32_indices.push(element.value() as u32 % self.window_size);
                 }
@@ -237,7 +237,7 @@ mod tests {
                     i,
                     vec![BFieldElement::new(*index as u64)],
                     memory,
-                );
+                )?;
             }
 
             // Compare derived indices to actual implementation (copy-pasted from
@@ -259,11 +259,9 @@ mod tests {
                 .collect_vec();
 
             // Sanity check that this RUST-shadowing agrees with the real deal
-            assert_eq!(
-                indices_from_mutator_set.to_vec(),
-                u128_indices,
-                "VM-calculated indices must match that from mutator set module"
-            );
+            if indices_from_mutator_set.to_vec() != u128_indices {
+                return Err(RustShadowError::Other);
+            }
 
             let u128_list_pointer =
                 rust_shadowing_helper_functions::dyn_malloc::dynamic_allocator(memory);
@@ -274,6 +272,7 @@ mod tests {
             );
 
             stack.push(u128_list_pointer);
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/neptune/mutator_set/get_swbf_indices.rs
+++ b/tasm-lib/src/neptune/mutator_set/get_swbf_indices.rs
@@ -314,7 +314,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test() {
         ShadowedFunction::new(GetSwbfIndices {
             window_size: 1048576,
@@ -329,7 +329,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(GetSwbfIndices {
             window_size: 1048576,

--- a/tasm-lib/src/rust_shadowing_helper_functions/dyn_malloc.rs
+++ b/tasm-lib/src/rust_shadowing_helper_functions/dyn_malloc.rs
@@ -10,6 +10,6 @@ use crate::traits::function::Function;
 /// state accordingly.
 pub fn dynamic_allocator(memory: &mut HashMap<BFieldElement, BFieldElement>) -> BFieldElement {
     let mut init_stack = empty_stack();
-    DynMalloc.rust_shadow(&mut init_stack, memory);
+    DynMalloc.rust_shadow(&mut init_stack, memory).unwrap();
     init_stack.pop().unwrap()
 }

--- a/tasm-lib/src/rust_shadowing_helper_functions/list.rs
+++ b/tasm-lib/src/rust_shadowing_helper_functions/list.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use num::Zero;
 use num_traits::ConstOne;
+use num_traits::ConstZero;
 use triton_vm::prelude::*;
 use twenty_first::math::other::random_elements;
 
@@ -10,48 +11,55 @@ use crate::USIZE_TO_U64_ERR;
 use crate::list::LIST_METADATA_SIZE;
 use crate::memory::dyn_malloc::DYN_MALLOC_PAGE_SIZE;
 use crate::prelude::*;
+use crate::traits::rust_shadow::RustShadowError;
 
 /// Load a list from memory returning each element as a list of `BFieldElement`s.
 pub fn load_list_unstructured(
     element_size: usize,
     list_pointer: BFieldElement,
     memory: &HashMap<BFieldElement, BFieldElement>,
-) -> Vec<Vec<BFieldElement>> {
-    let list_length: usize = memory[&list_pointer].value().try_into().unwrap();
+) -> Result<Vec<Vec<BFieldElement>>, RustShadowError> {
+    let list_length = list_get_length(list_pointer, memory)?;
+    let mut element_pointer = list_pointer + bfe!(LIST_METADATA_SIZE);
 
-    let mut element_pointer = list_pointer + BFieldElement::new(LIST_METADATA_SIZE as u64);
-
-    let mut ret = Vec::with_capacity(list_length);
-    for i in 0..list_length {
-        ret.push(vec![]);
+    let mut list = Vec::with_capacity(list_length);
+    for _ in 0..list_length {
+        let mut element = Vec::with_capacity(element_size);
         for _ in 0..element_size {
-            ret[i].push(memory[&element_pointer]);
+            let Some(element_part) = memory.get(&element_pointer).copied() else {
+                return Err(RustShadowError::DecodingError);
+            };
+            element.push(element_part);
             element_pointer.increment();
         }
+        list.push(element);
     }
 
-    ret
+    Ok(list)
 }
 
 /// Load a list from memory. Elements must be of `Copy` type.
 pub fn load_list_with_copy_elements<const ELEMENT_SIZE: usize>(
     list_pointer: BFieldElement,
     memory: &HashMap<BFieldElement, BFieldElement>,
-) -> Vec<[BFieldElement; ELEMENT_SIZE]> {
-    let list_length: usize = memory[&list_pointer].value().try_into().unwrap();
+) -> Result<Vec<[BFieldElement; ELEMENT_SIZE]>, RustShadowError> {
+    let list_length = list_get_length(list_pointer, memory)?;
+    let mut element_pointer = list_pointer + bfe!(LIST_METADATA_SIZE);
 
-    let mut element_pointer = list_pointer + BFieldElement::new(LIST_METADATA_SIZE as u64);
-
-    let mut ret = Vec::with_capacity(list_length);
-    for i in 0..list_length {
-        ret.push([BFieldElement::zero(); ELEMENT_SIZE]);
-        for item in ret[i].iter_mut() {
-            *item = memory[&element_pointer];
+    let mut list = Vec::with_capacity(list_length);
+    for _ in 0..list_length {
+        let mut element = [BFieldElement::ZERO; ELEMENT_SIZE];
+        for item in &mut element {
+            let Some(element_part) = memory.get(&element_pointer).copied() else {
+                return Err(RustShadowError::DecodingError);
+            };
+            *item = element_part;
             element_pointer.increment();
         }
+        list.push(element);
     }
 
-    ret
+    Ok(list)
 }
 
 pub fn list_insert<T: BFieldCodec>(
@@ -62,7 +70,7 @@ pub fn list_insert<T: BFieldCodec>(
     list_new(list_pointer, memory);
 
     for element in vector {
-        list_push(list_pointer, element.encode(), memory);
+        list_push(list_pointer, element.encode(), memory).unwrap();
     }
 }
 
@@ -90,60 +98,66 @@ pub fn untyped_insert_random_list(
     list_new(list_pointer, memory);
     for _ in 0..list_length {
         let random_element: Vec<BFieldElement> = random_elements(element_length);
-        list_push(list_pointer, random_element, memory);
+        list_push(list_pointer, random_element, memory).unwrap();
     }
 }
 
 pub fn list_new(list_pointer: BFieldElement, memory: &mut HashMap<BFieldElement, BFieldElement>) {
-    memory.insert(list_pointer, BFieldElement::zero());
+    memory.insert(list_pointer, BFieldElement::ZERO);
 }
 
 /// Push the given element to the pointed-to list.
 ///
 /// Only supports lists with statically sized elements.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if the pointed-to list is incorrectly encoded.
+/// Errors if the pointed-to list is incorrectly encoded.
 pub fn list_push(
     list_pointer: BFieldElement,
     value: Vec<BFieldElement>,
     memory: &mut HashMap<BFieldElement, BFieldElement>,
-) {
-    let list_length = memory
-        .get_mut(&list_pointer)
-        .expect("list must be initialized");
+) -> Result<(), RustShadowError> {
+    let Some(list_length) = memory.get_mut(&list_pointer) else {
+        return Err(RustShadowError::DecodingError);
+    };
     let len = list_length.value();
     list_length.increment();
 
     let element_size: u64 = value.len().try_into().expect(USIZE_TO_U64_ERR);
     let list_metadata_size: u64 = LIST_METADATA_SIZE.try_into().expect(USIZE_TO_U64_ERR);
     let highest_access_index = list_metadata_size + element_size * (len + 1);
-    assert!(highest_access_index < DYN_MALLOC_PAGE_SIZE);
+    if highest_access_index >= DYN_MALLOC_PAGE_SIZE {
+        return Err(RustShadowError::Other);
+    }
 
     for (i, word) in (0..).zip(value) {
         let word_offset = bfe!(list_metadata_size + element_size * len + i);
         memory.insert(list_pointer + word_offset, word);
     }
+
+    Ok(())
 }
 
 /// Pop an element from the pointed-to list.
 ///
 /// Only supports lists with statically sized elements.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if the pointed-to list is empty, or if the list is incorrectly
+/// Errors if the pointed-to list is empty, or if the list is incorrectly
 /// encoded.
 pub fn list_pop(
     list_pointer: BFieldElement,
     memory: &mut HashMap<BFieldElement, BFieldElement>,
     element_length: usize,
-) -> Vec<BFieldElement> {
-    let list_length = memory
-        .get_mut(&list_pointer)
-        .expect("list must be initialized");
-    assert_ne!(0, list_length.value(), "list must not be empty");
+) -> Result<Vec<BFieldElement>, RustShadowError> {
+    let Some(list_length) = memory.get_mut(&list_pointer) else {
+        return Err(RustShadowError::DecodingError);
+    };
+    if list_length.is_zero() {
+        return Err(RustShadowError::Other); // list must not be empty
+    }
     list_length.decrement();
     let last_item_index = list_length.value();
 
@@ -151,7 +165,10 @@ pub fn list_pop(
     let read_word = |i| {
         let word_offset = bfe!(LIST_METADATA_SIZE) + bfe!(element_length * last_item_index + i);
         let word_index = list_pointer + bfe!(word_offset);
-        memory[&word_index]
+        memory
+            .get(&word_index)
+            .copied()
+            .ok_or(RustShadowError::DecodingError)
     };
 
     (0..element_length).map(read_word).collect()
@@ -163,39 +180,52 @@ pub fn list_pop(
 /// Supports both, lists with statically _and_ lists with dynamically sized
 /// elements.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if the `index` is out of bounds, or if the pointed-to-list is
+/// Errors if the `index` is out of bounds, or if the pointed-to-list is
 /// incorrectly encoded.
 pub fn list_pointer_to_elem_pointer(
     list_pointer: BFieldElement,
     index: usize,
     memory: &HashMap<BFieldElement, BFieldElement>,
     element_type: &DataType,
-) -> (usize, BFieldElement) {
-    let list_len = list_get_length(list_pointer, memory);
-    assert!(index < list_len, "out of bounds: {index} >= {list_len}");
+) -> Result<(usize, BFieldElement), RustShadowError> {
+    let list_len = list_get_length(list_pointer, memory)?;
+    if index >= list_len {
+        return Err(RustShadowError::Other); // out of bounds
+    }
 
     if let Some(element_size) = element_type.static_length() {
         let elem_ptr = list_pointer + bfe!(LIST_METADATA_SIZE + index * element_size);
-        return (element_size, elem_ptr);
+        return Ok((element_size, elem_ptr));
     }
 
     let mut elem_pointer = list_pointer + bfe!(LIST_METADATA_SIZE);
     for _ in 0..index {
-        elem_pointer += memory[&elem_pointer] + BFieldElement::ONE;
+        elem_pointer += memory
+            .get(&elem_pointer)
+            .copied()
+            .ok_or(RustShadowError::DecodingError)?
+            + BFieldElement::ONE;
     }
-    let elem_size = usize::try_from(memory[&elem_pointer].value()).unwrap();
-    (elem_size, elem_pointer + BFieldElement::ONE)
+    let elem_size = memory
+        .get(&elem_pointer)
+        .copied()
+        .ok_or(RustShadowError::DecodingError)?;
+    let Ok(elem_size) = usize::try_from(elem_size.value()) else {
+        return Err(RustShadowError::U64ToUsizeError);
+    };
+
+    Ok((elem_size, elem_pointer + BFieldElement::ONE))
 }
 
 /// Read an element from a list.
 ///
 /// Only supports lists with statically sized elements.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if
+/// Errors if
 /// - the `index` is out of bounds, or
 /// - the element that is to be read resides outside the list`s
 ///   [memory page][crate::memory], or
@@ -205,17 +235,30 @@ pub fn list_get(
     index: usize,
     memory: &HashMap<BFieldElement, BFieldElement>,
     element_size: usize,
-) -> Vec<BFieldElement> {
-    let list_len = list_get_length(list_pointer, memory);
-    assert!(index < list_len, "out of bounds: {index} >= {list_len}");
+) -> Result<Vec<BFieldElement>, RustShadowError> {
+    let list_len = list_get_length(list_pointer, memory)?;
+    if index >= list_len {
+        return Err(RustShadowError::Other); // out of bounds
+    }
 
-    let highest_access_index = LIST_METADATA_SIZE + element_size * (index + 1);
-    assert!(u64::try_from(highest_access_index).expect(USIZE_TO_U64_ERR) < DYN_MALLOC_PAGE_SIZE);
+    // for the benefit of 32-bit architectures, convert before doing arithmetic
+    let to_u64 = |x| u64::try_from(x).expect(USIZE_TO_U64_ERR);
+    let metadata_size = to_u64(LIST_METADATA_SIZE);
+    let element_size = to_u64(element_size);
+    let index = to_u64(index);
+
+    let highest_access_index = metadata_size + element_size * (index + 1);
+    if highest_access_index >= DYN_MALLOC_PAGE_SIZE {
+        return Err(RustShadowError::Other);
+    }
 
     let read_word = |i| {
-        let word_offset = LIST_METADATA_SIZE + element_size * index + i;
+        let word_offset = metadata_size + element_size * index + i;
         let word_index = list_pointer + bfe!(word_offset);
-        memory[&word_index]
+        memory
+            .get(&word_index)
+            .copied()
+            .ok_or(RustShadowError::DecodingError)
     };
 
     (0..element_size).map(read_word).collect()
@@ -225,11 +268,11 @@ pub fn list_get(
 ///
 /// Only supports lists with statically sized elements.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if
+/// Errors if
 /// - the `index` is out of bounds, or
-/// - the element that is to be read resides outside the list`s
+/// - the element that is to be read resides outside the list’s
 ///   [memory page][crate::memory], or
 /// - the pointed-to-list is incorrectly encoded into `memory`.
 pub fn list_set(
@@ -237,28 +280,39 @@ pub fn list_set(
     index: usize,
     value: Vec<BFieldElement>,
     memory: &mut HashMap<BFieldElement, BFieldElement>,
-) {
-    let list_len = list_get_length(list_pointer, memory);
-    assert!(index < list_len, "out of bounds: {index} >= {list_len}");
+) -> Result<(), RustShadowError> {
+    let list_len = list_get_length(list_pointer, memory)?;
+    if index >= list_len {
+        return Err(RustShadowError::Other); // out of bounds
+    }
 
     let element_size = value.len();
     let highest_access_index = LIST_METADATA_SIZE + element_size * (index + 1);
-    assert!(u64::try_from(highest_access_index).expect(USIZE_TO_U64_ERR) < DYN_MALLOC_PAGE_SIZE);
+    if u64::try_from(highest_access_index).expect(USIZE_TO_U64_ERR) >= DYN_MALLOC_PAGE_SIZE {
+        return Err(RustShadowError::Other);
+    }
 
     for (i, word) in value.into_iter().enumerate() {
         let word_offset = LIST_METADATA_SIZE + element_size * index + i;
         let word_index = list_pointer + bfe!(word_offset);
         memory.insert(word_index, word);
     }
+
+    Ok(())
 }
 
 pub fn list_get_length(
     list_pointer: BFieldElement,
     memory: &HashMap<BFieldElement, BFieldElement>,
-) -> usize {
-    let length: u32 = memory[&list_pointer].value().try_into().unwrap();
+) -> Result<usize, RustShadowError> {
+    let Some(length) = memory.get(&list_pointer).copied() else {
+        return Err(RustShadowError::DecodingError);
+    };
+    let Ok(length) = u32::try_from(length.value()) else {
+        return Err(RustShadowError::U64ToU32Error);
+    };
 
-    length.try_into().expect(U32_TO_USIZE_ERR)
+    Ok(length.try_into().expect(U32_TO_USIZE_ERR))
 }
 
 pub fn list_set_length(
@@ -279,10 +333,10 @@ mod tests {
         let mut memory = HashMap::default();
         let list_pointer = BFieldElement::new(20);
         list_new(list_pointer, &mut memory);
-        assert!(list_get_length(list_pointer, &memory).is_zero());
+        assert!(list_get_length(list_pointer, &memory).unwrap().is_zero());
         let new_length = 51;
         list_set_length(list_pointer, new_length, &mut memory);
-        assert_eq!(new_length, list_get_length(list_pointer, &memory));
+        assert_eq!(new_length, list_get_length(list_pointer, &memory).unwrap());
     }
 
     #[macro_rules_attr::apply(proptest)]
@@ -302,7 +356,7 @@ mod tests {
         let data_type = DataType::Digest;
         for (i, digest) in list.into_iter().enumerate() {
             dbg!(i);
-            let (len, ptr) = list_pointer_to_elem_pointer(list_pointer, i, &memory, &data_type);
+            let (len, ptr) = list_pointer_to_elem_pointer(list_pointer, i, &memory, &data_type)?;
             prop_assert_eq!(Digest::LEN, len);
             prop_assert_eq!(digest.values()[0], memory[&ptr]);
         }
@@ -325,7 +379,7 @@ mod tests {
         let data_type = DataType::List(Box::new(DataType::Bfe));
         for (i, inner_list) in list.into_iter().enumerate() {
             dbg!(i);
-            let (len, ptr) = list_pointer_to_elem_pointer(list_pointer, i, &memory, &data_type);
+            let (len, ptr) = list_pointer_to_elem_pointer(list_pointer, i, &memory, &data_type)?;
             prop_assert_eq!(inner_list.encode().len(), len);
             prop_assert_eq!(bfe!(inner_list.len()), memory[&ptr]);
         }

--- a/tasm-lib/src/rust_shadowing_helper_functions/list.rs
+++ b/tasm-lib/src/rust_shadowing_helper_functions/list.rs
@@ -271,13 +271,10 @@ pub fn list_set_length(
 
 #[cfg(test)]
 mod tests {
-    use proptest::prop_assert_eq;
-    use proptest_arbitrary_interop::arb;
-    use test_strategy::proptest;
-
     use super::*;
+    use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn new_list_set_length() {
         let mut memory = HashMap::default();
         let list_pointer = BFieldElement::new(20);
@@ -288,7 +285,7 @@ mod tests {
         assert_eq!(new_length, list_get_length(list_pointer, &memory));
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn element_pointer_from_list_pointer_on_static_list_with_static_length_items(
         #[strategy(arb())] list: Vec<Digest>,
         #[strategy(arb())] list_pointer: BFieldElement,
@@ -311,7 +308,7 @@ mod tests {
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn element_pointer_from_list_pointer_on_static_list_with_dyn_length_items(
         #[strategy(arb())] list: Vec<Vec<BFieldElement>>,
         #[strategy(arb())] list_pointer: BFieldElement,

--- a/tasm-lib/src/snippet_bencher.rs
+++ b/tasm-lib/src/snippet_bencher.rs
@@ -1,11 +1,5 @@
-use std::fs::File;
-use std::fs::create_dir_all;
-use std::path::Path;
-use std::path::PathBuf;
-
 use serde::Deserialize;
 use serde::Serialize;
-use serde_json::to_writer_pretty;
 use triton_vm::aet::AlgebraicExecutionTrace;
 use triton_vm::prelude::TableId;
 
@@ -43,20 +37,27 @@ impl BenchmarkResult {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub fn write_benchmarks(benchmarks: Vec<NamedBenchmarkResult>) {
-    let mut path = PathBuf::new();
-    path.push("benchmarks");
-    create_dir_all(&path).expect("benchmarks directory should exist");
-
-    let function_name = &benchmarks[0].name;
-    for fnname in benchmarks.iter().map(|x| &x.name) {
-        assert_eq!(
-            function_name, fnname,
-            "all fn names must agree for benchmark writing to disk"
-        );
+    if benchmarks.is_empty() {
+        return;
     }
 
-    path.push(Path::new(&function_name).with_extension("json"));
-    let output = File::create(&path).expect("open file for writing");
-    to_writer_pretty(output, &benchmarks).expect("write json to file");
+    let mut path = std::path::PathBuf::new();
+    path.push("benchmarks");
+    std::fs::create_dir_all(&path).expect("benchmarks directory should exist");
+
+    let function_name = benchmarks[0].name.as_str();
+    assert!(
+        benchmarks.iter().all(|bench| bench.name == function_name),
+        "all fn names must agree for benchmark writing to disk",
+    );
+
+    path.push(std::path::Path::new(function_name).with_extension("json"));
+    let output = std::fs::File::create(&path).expect("open file for writing");
+    serde_json::to_writer_pretty(output, &benchmarks).expect("write json to file");
 }
+
+// file access is not possible on `wasm32` architectures; ignore attempts
+#[cfg(target_arch = "wasm32")]
+pub fn write_benchmarks(_: Vec<NamedBenchmarkResult>) {}

--- a/tasm-lib/src/structure/manual_tasm_object_implementations.rs
+++ b/tasm-lib/src/structure/manual_tasm_object_implementations.rs
@@ -595,14 +595,9 @@ mod tests {
     use std::collections::HashMap;
     use std::fmt::Debug;
 
-    use proptest::prelude::*;
-    use proptest::test_runner::TestCaseResult;
-    use proptest_arbitrary_interop::arb;
-    use test_strategy::Arbitrary;
-    use test_strategy::proptest;
-
     use super::*;
     use crate::memory::encode_to_memory;
+    use crate::test_prelude::*;
 
     #[derive(Debug, Clone, Arbitrary)]
     struct TestObject<T>
@@ -636,7 +631,7 @@ mod tests {
     /// Generate a test case with the specified name for the specified type.
     macro_rules! gen_test {
         (fn $test_fn:ident for $type:ty) => {
-            #[proptest]
+            #[macro_rules_attr::apply(proptest)]
             fn $test_fn(test_object: TestObject<$type>) {
                 test_object.verify_decoding_properties()?;
             }

--- a/tasm-lib/src/structure/tasm_object.rs
+++ b/tasm-lib/src/structure/tasm_object.rs
@@ -274,7 +274,7 @@ mod tests {
     #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec, TasmObject, Arbitrary)]
     struct InnerStruct(XFieldElement, u32);
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_load_and_decode_from_memory() {
         #[derive(Debug, Clone, PartialEq, Eq, BFieldCodec, TasmObject)]
         struct OuterStruct {
@@ -335,7 +335,7 @@ mod tests {
         use super::*;
         use crate::maybe_write_debuggable_vm_state_to_disk;
 
-        #[test]
+        #[macro_rules_attr::apply(test)]
         fn load_and_decode_struct_with_named_fields_from_memory() {
             #[derive(BFieldCodec, TasmObject, PartialEq, Eq, Clone, Debug, Arbitrary)]
             struct NamedFields {
@@ -513,7 +513,7 @@ mod tests {
             }
         }
 
-        #[test]
+        #[macro_rules_attr::apply(test)]
         fn mess_with_size_indicator_field_getter_named_fields_negative_test() {
             #[derive(BFieldCodec, TasmObject, PartialEq, Eq, Clone, Debug, Arbitrary)]
             struct WithNamedFields {
@@ -563,7 +563,7 @@ mod tests {
             );
         }
 
-        #[test]
+        #[macro_rules_attr::apply(test)]
         fn mess_with_size_indicators_field_and_size_getter_negative_test() {
             const START_OF_OBJ: BFieldElement = BFieldElement::ZERO;
             let random_object = prepare_random_tuple_struct(rand::random());
@@ -599,7 +599,7 @@ mod tests {
             );
         }
 
-        #[test]
+        #[macro_rules_attr::apply(test)]
         fn mess_with_size_indicators_field_getter_negative_test() {
             const START_OF_OBJ: BFieldElement = BFieldElement::ZERO;
             let random_object = prepare_random_tuple_struct(rand::random());
@@ -632,7 +632,7 @@ mod tests {
             );
         }
 
-        #[test]
+        #[macro_rules_attr::apply(test)]
         fn mess_with_size_indicators_size_indicator_validity_check_negative_test() {
             let mut library = Library::default();
             const OBJ_POINTER: BFieldElement = BFieldElement::new(422);
@@ -682,7 +682,7 @@ mod tests {
             }
         }
 
-        #[test]
+        #[macro_rules_attr::apply(test)]
         fn mess_with_size_indicators_checked_size_list_w_dyn_sized_elems_negative_test() {
             #[derive(BFieldCodec, TasmObject, Debug, Clone, Arbitrary)]
             struct ListDynSizedElements {
@@ -737,7 +737,7 @@ mod tests {
             )
         }
 
-        #[test]
+        #[macro_rules_attr::apply(test)]
         fn validate_total_size_statically_sized_struct() {
             #[derive(BFieldCodec, TasmObject, Debug, Clone, Copy)]
             struct StaticallySizedStruct {
@@ -780,7 +780,7 @@ mod tests {
             assert_eq!(expected_stack, actual_stack);
         }
 
-        #[test]
+        #[macro_rules_attr::apply(test)]
         fn load_and_decode_tuple_structs_from_memory() {
             let random_object = prepare_random_tuple_struct(rand::random());
             let random_address: u64 = rand::rng().random_range(0..(1 << 30));
@@ -826,7 +826,7 @@ mod tests {
             assert_eq!(random_object.0.len(), extracted_xfe_count);
         }
 
-        #[test]
+        #[macro_rules_attr::apply(test)]
         fn test_fri_response() {
             let mut rng = rand::rng();
             let num_digests = 50;
@@ -918,7 +918,7 @@ mod tests {
         use crate::neptune::neptune_like_types_for_tests::UpdateWitnessLookalike;
         use crate::twenty_first::util_types::mmr::mmr_accumulator::MmrAccumulator;
 
-        #[test]
+        #[macro_rules_attr::apply(test)]
         fn unit_struct() {
             #[derive(BFieldCodec, TasmObject)]
             struct Empty {}
@@ -969,7 +969,7 @@ mod tests {
             // re-design it.
             macro_rules! one_field_test_case {
                 (fn $test_name:ident for $ty:ident: $f_name:tt $($post_process:tt)*) => {
-                    #[proptest]
+                    #[macro_rules_attr::apply(proptest)]
                     fn $test_name(
                         #[strategy(arb())] foo: $ty,
                         #[strategy(arb())] ptr: BFieldElement,
@@ -1079,7 +1079,7 @@ mod tests {
                     ($f_name_0:tt $($post_process_0:tt)*)
                     ($f_name_1:tt $($post_process_1:tt)*)
                 ) => {
-                    #[proptest]
+                    #[macro_rules_attr::apply(proptest)]
                     fn $test_name(
                         #[strategy(arb())] foo: $ty,
                         #[strategy(arb())] ptr: BFieldElement,
@@ -1125,7 +1125,7 @@ mod tests {
             two_fields_test_case!( fn named_nest_nest for NamedNestNest: (a.len()) (b.len()) );
         }
 
-        #[test]
+        #[macro_rules_attr::apply(test)]
         fn all_static_dynamic_neighbor_combinations() {
             /// A struct where all neighbor combinations of fields with
             /// {static, dynamic}×{static, dynamic} sizes occur.
@@ -1187,7 +1187,7 @@ mod tests {
             assert_eq!(foo, foo_again);
         }
 
-        #[proptest]
+        #[macro_rules_attr::apply(proptest)]
         fn destructure_update_witness(
             #[strategy(arb())] witness: UpdateWitnessLookalike,
             #[strategy(arb())] witness_ptr: BFieldElement,
@@ -1246,7 +1246,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_option() {
         let mut rng = rand::rng();
         let n = rng.random_range(0..5);
@@ -1264,7 +1264,7 @@ mod tests {
         assert!(none_decoded.is_none());
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn iter_decoding_too_short_sequence_does_not_panic(
         #[strategy(arb())] object: Vec<Vec<Digest>>,
         num_elements_to_drop: usize,

--- a/tasm-lib/src/structure/verify_nd_si_integrity.rs
+++ b/tasm-lib/src/structure/verify_nd_si_integrity.rs
@@ -112,18 +112,28 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &HashMap<BFieldElement, BFieldElement>,
-        ) {
+        ) -> Result<(), RustShadowError> {
             // If the type can be decoded then it must have valid size indicators
-            let pointer = stack.pop().unwrap();
-            let obj = T::decode_from_memory(memory, pointer).unwrap();
+            let pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let obj = T::decode_from_memory(memory, pointer)
+                .map_err(|_| RustShadowError::DecodingError)?;
             let encoding_len = obj.encode().len();
-            let encoding_len: u32 = encoding_len.try_into().unwrap();
+            let encoding_len: u32 = encoding_len
+                .try_into()
+                .map_err(|_| RustShadowError::UsizeToU32Error)?;
 
             // Verify contained in ND-region
-            let start_address: u32 = pointer.value().try_into().unwrap();
-            let _end_address = start_address.checked_add(encoding_len).unwrap();
+            let start_address: u32 = pointer
+                .value()
+                .try_into()
+                .map_err(|_| RustShadowError::U64ToU32Error)?;
+            let _end_address = start_address
+                .checked_add(encoding_len)
+                .ok_or(RustShadowError::ArithmeticOverflow)?;
 
-            stack.push(bfe!(obj.encode().len() as u64));
+            stack.push(bfe!(u64::from(encoding_len)));
+
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/structure/verify_nd_si_integrity.rs
+++ b/tasm-lib/src/structure/verify_nd_si_integrity.rs
@@ -161,13 +161,13 @@ mod tests {
 
     macro_rules! test_case {
         (fn $test_name:ident for $t:ty) => {
-            #[test]
+            #[macro_rules_attr::apply(test)]
             fn $test_name() {
                 ShadowedAccessor::new(VerifyNdSiIntegrity::<$t>::default()).test();
             }
         };
         (fn $test_name:ident for new type $t:ty: $($type_declaration:tt)*) => {
-            #[test]
+            #[macro_rules_attr::apply(test)]
             fn $test_name() {
                 #[derive(Debug, Clone, TasmObject, BFieldCodec, Arbitrary)]
                 $($type_declaration)*
@@ -190,7 +190,7 @@ mod tests {
 
         test_case! { fn test_pbt_simple_struct for TestStruct }
 
-        #[test]
+        #[macro_rules_attr::apply(test)]
         fn struct_not_contained_in_nd_region() {
             let snippet = VerifyNdSiIntegrity::<TestStruct>::default();
 
@@ -209,7 +209,7 @@ mod tests {
             )
         }
 
-        #[test]
+        #[macro_rules_attr::apply(test)]
         fn struct_does_not_start_in_nd_region() {
             let snippet = VerifyNdSiIntegrity::<TestStruct>::default();
 
@@ -225,7 +225,7 @@ mod tests {
             )
         }
 
-        #[test]
+        #[macro_rules_attr::apply(test)]
         fn lie_about_digest_vec_size() {
             let snippet = VerifyNdSiIntegrity::<TestStruct>::default();
 
@@ -240,7 +240,7 @@ mod tests {
             test_assertion_failure(&ShadowedAccessor::new(snippet), init_state.into(), &[181])
         }
 
-        #[test]
+        #[macro_rules_attr::apply(test)]
         fn lie_about_digest_vec_len() {
             let snippet = VerifyNdSiIntegrity::<TestStruct>::default();
 
@@ -277,7 +277,7 @@ mod tests {
         test_case! {fn test_option_stat_sized_elem for StatSizedPayload }
         test_case! {fn test_option_dyn_sized_elem for DynSizedPayload }
 
-        #[test]
+        #[macro_rules_attr::apply(test)]
         fn lie_about_option_payload_field_size() {
             let snippet = VerifyNdSiIntegrity::<DynSizedPayload>::default();
 
@@ -301,7 +301,7 @@ mod tests {
             );
         }
 
-        #[test]
+        #[macro_rules_attr::apply(test)]
         fn illegal_discriminant_value_for_option() {
             let snippet = VerifyNdSiIntegrity::<DynSizedPayload>::default();
 
@@ -320,7 +320,7 @@ mod tests {
             );
         }
 
-        #[test]
+        #[macro_rules_attr::apply(test)]
         fn lie_about_option_payload_size() {
             let snippet = VerifyNdSiIntegrity::<DynSizedPayload>::default();
 
@@ -406,12 +406,12 @@ mod benches {
     use crate::neptune::neptune_like_types_for_tests::TransactionKernelLookalike;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_proof_collection_lookalike() {
         ShadowedAccessor::new(VerifyNdSiIntegrity::<ProofCollectionLookalike>::default()).bench();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_transaction_kernel_lookalike() {
         ShadowedAccessor::new(VerifyNdSiIntegrity::<TransactionKernelLookalike>::default()).bench();
     }

--- a/tasm-lib/src/test_helpers.rs
+++ b/tasm-lib/src/test_helpers.rs
@@ -13,6 +13,7 @@ use crate::execute_with_terminal_state;
 use crate::prelude::Tip5;
 use crate::traits::basic_snippet::SignedOffSnippet;
 use crate::traits::rust_shadow::RustShadow;
+use crate::traits::rust_shadow::RustShadowError;
 
 pub fn rust_final_state<T: RustShadow>(
     shadowed_snippet: &T,
@@ -26,13 +27,15 @@ pub fn rust_final_state<T: RustShadow>(
     let mut rust_sponge = sponge.clone();
 
     // run rust shadow
-    let output = shadowed_snippet.rust_shadow_wrapper(
-        stdin,
-        nondeterminism,
-        &mut rust_stack,
-        &mut rust_memory,
-        &mut rust_sponge,
-    );
+    let output = shadowed_snippet
+        .rust_shadow_wrapper(
+            stdin,
+            nondeterminism,
+            &mut rust_stack,
+            &mut rust_memory,
+            &mut rust_sponge,
+        )
+        .unwrap();
 
     RustShadowOutputState {
         public_output: output,
@@ -48,7 +51,7 @@ pub fn tasm_final_state<T: RustShadow>(
     stdin: &[BFieldElement],
     nondeterminism: NonDeterminism,
     sponge: &Option<Tip5>,
-) -> VMState {
+) -> Result<VMState, RustShadowError> {
     // run tvm
     link_and_run_tasm_for_test(
         shadowed_snippet,
@@ -177,7 +180,8 @@ pub fn test_rust_equivalence_given_complete_state<T: RustShadow>(
         stdin,
         nondeterminism.clone(),
         sponge,
-    );
+    )
+    .unwrap();
 
     assert_eq!(
         rust.public_output, tasm.public_output,
@@ -205,7 +209,7 @@ pub fn link_and_run_tasm_for_test<T: RustShadow>(
     std_in: Vec<BFieldElement>,
     nondeterminism: NonDeterminism,
     maybe_sponge: Option<Tip5>,
-) -> VMState {
+) -> Result<VMState, RustShadowError> {
     let code = snippet_struct.inner().link_for_isolated_run();
 
     execute_test(
@@ -273,23 +277,17 @@ fn instruction_error_from_failing_code<S: RustShadow>(
     snippet: &S,
     init_state: InitVmState,
 ) -> InstructionError {
-    // `AssertUnwindSafe` is fine because the caught panic is discarded immediately
-    let rust_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        let mut rust_stack = init_state.stack.clone();
-        let mut rust_memory = init_state.nondeterminism.ram.clone();
-        let mut rust_sponge = init_state.sponge.clone();
-        snippet.rust_shadow_wrapper(
-            &init_state.public_input,
-            &init_state.nondeterminism,
-            &mut rust_stack,
-            &mut rust_memory,
-            &mut rust_sponge,
-        )
-    }));
-    assert!(
-        rust_result.is_err(),
-        "Failed to fail: Rust-shadowing must panic in negative test case"
+    let mut rust_stack = init_state.stack.clone();
+    let mut rust_memory = init_state.nondeterminism.ram.clone();
+    let mut rust_sponge = init_state.sponge.clone();
+    let rust_result = snippet.rust_shadow_wrapper(
+        &init_state.public_input,
+        &init_state.nondeterminism,
+        &mut rust_stack,
+        &mut rust_memory,
+        &mut rust_sponge,
     );
+    rust_result.expect_err("Failed to fail: Rust-shadowing must panic in negative test case");
 
     let code = snippet.inner().link_for_isolated_run();
     let tvm_result = execute_with_terminal_state(
@@ -299,7 +297,6 @@ fn instruction_error_from_failing_code<S: RustShadow>(
         &init_state.nondeterminism,
         init_state.sponge,
     );
-
     tvm_result.expect_err("Failed to fail: Triton VM execution must crash in negative test case")
 }
 
@@ -322,11 +319,7 @@ pub fn prepend_program_with_sponge_init(program: &Program) -> Program {
 
 /// Store the output from Triton VM's `proof` function as files, such that a deterministic
 /// proof can be used for debugging purposes.
-pub fn maybe_write_tvm_output_to_disk(
-    stark: &Stark,
-    claim: &triton_vm::proof::Claim,
-    proof: &Proof,
-) {
+pub fn maybe_write_tvm_output_to_disk(stark: &Stark, claim: &Claim, proof: &Proof) {
     use std::io::Write;
     let Ok(_) = std::env::var("TASMLIB_STORE") else {
         return;

--- a/tasm-lib/src/traits/accessor.rs
+++ b/tasm-lib/src/traits/accessor.rs
@@ -5,6 +5,7 @@ use triton_vm::prelude::*;
 
 use super::basic_snippet::BasicSnippet;
 use super::rust_shadow::RustShadow;
+use super::rust_shadow::RustShadowError;
 use crate::InitVmState;
 use crate::linker::execute_bench;
 use crate::prelude::Tip5;
@@ -33,7 +34,7 @@ pub trait Accessor: BasicSnippet {
         &self,
         stack: &mut Vec<BFieldElement>,
         memory: &HashMap<BFieldElement, BFieldElement>,
-    );
+    ) -> Result<(), RustShadowError>;
 
     fn pseudorandom_initial_state(
         &self,
@@ -42,7 +43,7 @@ pub trait Accessor: BasicSnippet {
     ) -> AccessorInitialState;
 
     fn corner_case_initial_states(&self) -> Vec<AccessorInitialState> {
-        vec![]
+        Vec::new()
     }
 }
 
@@ -88,9 +89,10 @@ where
         stack: &mut Vec<BFieldElement>,
         memory: &mut HashMap<BFieldElement, BFieldElement>,
         _sponge: &mut Option<Tip5>,
-    ) -> Vec<BFieldElement> {
-        self.accessor.rust_shadow(stack, memory);
-        vec![]
+    ) -> Result<Vec<BFieldElement>, RustShadowError> {
+        self.accessor.rust_shadow(stack, memory)?;
+
+        Ok(Vec::new())
     }
 
     fn test(&self) {

--- a/tasm-lib/src/traits/algorithm.rs
+++ b/tasm-lib/src/traits/algorithm.rs
@@ -5,6 +5,7 @@ use triton_vm::prelude::*;
 
 use super::basic_snippet::BasicSnippet;
 use super::rust_shadow::RustShadow;
+use super::rust_shadow::RustShadowError;
 use crate::InitVmState;
 use crate::linker::execute_bench;
 use crate::prelude::Tip5;
@@ -34,7 +35,7 @@ pub trait Algorithm: BasicSnippet {
         stack: &mut Vec<BFieldElement>,
         memory: &mut HashMap<BFieldElement, BFieldElement>,
         nondeterminism: &NonDeterminism,
-    );
+    ) -> Result<(), RustShadowError>;
 
     /// Take a object about which something is being proven in order to extract out the
     /// right nondeterminism. Update the mutably referenced non-determism argument.
@@ -109,9 +110,10 @@ where
         stack: &mut Vec<BFieldElement>,
         memory: &mut HashMap<BFieldElement, BFieldElement>,
         _sponge: &mut Option<Tip5>,
-    ) -> Vec<BFieldElement> {
-        self.algorithm.rust_shadow(stack, memory, nondeterminism);
-        vec![]
+    ) -> Result<Vec<BFieldElement>, RustShadowError> {
+        self.algorithm.rust_shadow(stack, memory, nondeterminism)?;
+
+        Ok(Vec::new())
     }
 
     fn test(&self) {

--- a/tasm-lib/src/traits/basic_snippet.rs
+++ b/tasm-lib/src/traits/basic_snippet.rs
@@ -376,7 +376,19 @@ pub trait SignedOffSnippet: BasicSnippet {
 
     /// Panics if any [sign-offs](BasicSnippet::sign_offs) disagree with the actual
     /// [fingerprint](Self::fingerprint).
+    #[cfg_attr(
+        not(any(target_os = "linux", target_os = "macos", target_os = "windows")),
+        allow(unreachable_code)
+    )]
     fn assert_all_sign_offs_are_up_to_date(&self) {
+        // Program fingerprinting relies on the (derived) implementation of
+        // `Hash` for `LabelledInstruction` and `DefaultHasher`, neither of
+        // which is portable across platforms. In practice, it seems that things
+        // are portable enough across the three major operating system families,
+        // but not for architectures like `wam32`.
+        #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+        return;
+
         let fingerprint = self.fingerprint();
         let mut out_of_date_sign_offs = self
             .sign_offs()
@@ -431,6 +443,7 @@ impl From<u64> for SignOffFingerprint {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_prelude::*;
 
     macro_rules! dummy_snippet {
         ($name:ident: $($instr:tt)+) => {
@@ -453,7 +466,7 @@ mod tests {
 
     dummy_snippet!(DummySnippet: dummysnippet: push 14 push 14 pop 2 return);
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn init_stack_agrees_with_tvm() {
         // Verify that our assumptions about the initial stack at program start
         // agrees with Triton VM.
@@ -465,7 +478,7 @@ mod tests {
         assert_eq!(init_vm_state.op_stack.stack, calculated_init_stack);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn defined_traits_are_dyn_compatible() {
         fn basic_snippet_is_dyn_compatible(snippet: Box<dyn BasicSnippet>) {
             snippet.fingerprint();
@@ -479,7 +492,7 @@ mod tests {
         signed_off_snippet_is_dyn_compatible(Box::new(DummySnippet));
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn call_targets_dont_influence_snippet_fingerprints() {
         dummy_snippet!(SomeLabel: call some_label);
         dummy_snippet!(OtherLabel: call other_label);
@@ -487,7 +500,7 @@ mod tests {
         assert_eq!(SomeLabel.fingerprint(), OtherLabel.fingerprint());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_arguments_do_influence_snippet_fingerprints() {
         dummy_snippet!(Push20: push 20);
         dummy_snippet!(Push42: push 42);

--- a/tasm-lib/src/traits/closure.rs
+++ b/tasm-lib/src/traits/closure.rs
@@ -3,6 +3,7 @@ use triton_vm::prelude::*;
 
 use super::basic_snippet::BasicSnippet;
 use super::rust_shadow::RustShadow;
+use super::rust_shadow::RustShadowError;
 use crate::linker::execute_bench;
 use crate::prelude::Tip5;
 use crate::push_encodable;
@@ -32,14 +33,14 @@ pub trait Closure: BasicSnippet {
     /// top of the stack as the last element of the tuple.
     type Args: BFieldCodec;
 
-    fn rust_shadow(&self, stack: &mut Vec<BFieldElement>);
+    fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError>;
 
     /// Given a [seed](StdRng::Seed), generate pseudorandom [arguments](Self::Args),
     /// from which an [initial stack](Self::set_up_test_stack) can be constructed.
     fn pseudorandom_args(&self, seed: [u8; 32], bench_case: Option<BenchmarkCase>) -> Self::Args;
 
     fn corner_case_args(&self) -> Vec<Self::Args> {
-        vec![]
+        Vec::new()
     }
 
     fn set_up_test_stack(&self, args: Self::Args) -> Vec<BFieldElement> {
@@ -71,9 +72,10 @@ impl<C: Closure> RustShadow for ShadowedClosure<C> {
         stack: &mut Vec<BFieldElement>,
         _memory: &mut std::collections::HashMap<BFieldElement, BFieldElement>,
         _sponge: &mut Option<Tip5>,
-    ) -> Vec<BFieldElement> {
-        self.closure.rust_shadow(stack);
-        vec![]
+    ) -> Result<Vec<BFieldElement>, RustShadowError> {
+        self.closure.rust_shadow(stack)?;
+
+        Ok(Vec::new())
     }
 
     fn test(&self) {

--- a/tasm-lib/src/traits/compiled_program.rs
+++ b/tasm-lib/src/traits/compiled_program.rs
@@ -14,6 +14,7 @@ pub trait CompiledProgram {
     fn program() -> Program {
         let (program_instructions, library) = Self::code();
         let library_instructions = library.all_imports();
+
         Program::new(&[program_instructions, library_instructions].concat())
     }
 
@@ -120,6 +121,7 @@ mod tests {
                 a = b;
                 b = c;
             }
+
             Ok(vec![b])
         }
 

--- a/tasm-lib/src/traits/compiled_program.rs
+++ b/tasm-lib/src/traits/compiled_program.rs
@@ -53,12 +53,6 @@ pub fn bench_and_profile_program<P: CompiledProgram>(
     public_input: &PublicInput,
     nondeterminism: &NonDeterminism,
 ) {
-    use std::fs::File;
-    use std::fs::create_dir_all;
-    use std::io::Write;
-    use std::path::Path;
-    use std::path::PathBuf;
-
     use crate::snippet_bencher::NamedBenchmarkResult;
 
     let (program_instructions, library) = P::code();
@@ -84,21 +78,32 @@ pub fn bench_and_profile_program<P: CompiledProgram>(
 
     // write profile to standard output in case someone is watching
     let profile = crate::generate_full_profile(name, program, public_input, nondeterminism);
+    write_profile(name, &profile);
     println!("{profile}");
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn write_profile(name: &str, profile: &str) {
+    use std::io::Write;
 
     // write profile to profile file
-    let mut path = PathBuf::new();
+    let mut path = std::path::PathBuf::new();
     path.push("profiles");
-    create_dir_all(&path).expect("profiles directory should exist");
+    std::fs::create_dir_all(&path).expect("profiles directory should exist");
 
-    path.push(Path::new(name).with_extension("profile"));
-    let mut file = File::create(path).expect("open file for writing");
+    path.push(std::path::Path::new(name).with_extension("profile"));
+    let mut file = std::fs::File::create(path).expect("open file for writing");
     write!(file, "{profile}").unwrap();
 }
+
+// file access is not possible on `wasm32` architectures; ignore attempts
+#[cfg(target_arch = "wasm32")]
+fn write_profile(_: &str, _: &str) {}
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_prelude::*;
 
     pub(super) struct FiboTest;
 
@@ -146,7 +151,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_fibo_shadow() {
         let public_input = PublicInput::new(vec![BFieldElement::new(501)]);
         let nondeterminism = NonDeterminism::new(vec![]);
@@ -158,9 +163,9 @@ mod tests {
 mod benches {
     use super::tests::FiboTest;
     use super::*;
-    use crate::snippet_bencher::BenchmarkCase;
+    use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_fibo() {
         let public_input = PublicInput::new(vec![BFieldElement::new(501)]);
         let secret_input = NonDeterminism::new(vec![]);

--- a/tasm-lib/src/traits/function.rs
+++ b/tasm-lib/src/traits/function.rs
@@ -5,6 +5,7 @@ use triton_vm::prelude::*;
 
 use super::basic_snippet::BasicSnippet;
 use super::rust_shadow::RustShadow;
+use super::rust_shadow::RustShadowError;
 use crate::InitVmState;
 use crate::linker::execute_bench;
 use crate::prelude::Tip5;
@@ -35,7 +36,7 @@ pub trait Function: BasicSnippet {
         &self,
         stack: &mut Vec<BFieldElement>,
         memory: &mut HashMap<BFieldElement, BFieldElement>,
-    );
+    ) -> Result<(), RustShadowError>;
 
     /// Return (init_stack, init_memory)
     fn pseudorandom_initial_state(
@@ -45,7 +46,7 @@ pub trait Function: BasicSnippet {
     ) -> FunctionInitialState;
 
     fn corner_case_initial_states(&self) -> Vec<FunctionInitialState> {
-        vec![]
+        Vec::new()
     }
 }
 
@@ -112,9 +113,10 @@ where
         stack: &mut Vec<BFieldElement>,
         memory: &mut HashMap<BFieldElement, BFieldElement>,
         _sponge: &mut Option<Tip5>,
-    ) -> Vec<BFieldElement> {
-        self.function.rust_shadow(stack, memory);
-        vec![]
+    ) -> Result<Vec<BFieldElement>, RustShadowError> {
+        self.function.rust_shadow(stack, memory)?;
+
+        Ok(Vec::new())
     }
 
     /// Test rust-tasm equivalence.

--- a/tasm-lib/src/traits/mem_preserver.rs
+++ b/tasm-lib/src/traits/mem_preserver.rs
@@ -6,6 +6,7 @@ use triton_vm::prelude::*;
 
 use super::basic_snippet::BasicSnippet;
 use super::rust_shadow::RustShadow;
+use super::rust_shadow::RustShadowError;
 use crate::InitVmState;
 use crate::linker::execute_bench;
 use crate::snippet_bencher::BenchmarkCase;
@@ -36,7 +37,7 @@ pub trait MemPreserver: BasicSnippet {
         nd_digests: VecDeque<Digest>,
         stdin: VecDeque<BFieldElement>,
         sponge: &mut Option<Tip5>,
-    ) -> Vec<BFieldElement>;
+    ) -> Result<Vec<BFieldElement>, RustShadowError>;
 
     fn pseudorandom_initial_state(
         &self,
@@ -45,7 +46,7 @@ pub trait MemPreserver: BasicSnippet {
     ) -> MemPreserverInitialState;
 
     fn corner_case_initial_states(&self) -> Vec<MemPreserverInitialState> {
-        vec![]
+        Vec::new()
     }
 }
 
@@ -93,7 +94,7 @@ where
         stack: &mut Vec<BFieldElement>,
         memory: &mut HashMap<BFieldElement, BFieldElement>,
         sponge: &mut Option<Tip5>,
-    ) -> Vec<BFieldElement> {
+    ) -> Result<Vec<BFieldElement>, RustShadowError> {
         self.mem_preserver.rust_shadow(
             stack,
             memory,

--- a/tasm-lib/src/traits/procedure.rs
+++ b/tasm-lib/src/traits/procedure.rs
@@ -12,6 +12,7 @@ use crate::snippet_bencher::write_benchmarks;
 use crate::test_helpers::test_rust_equivalence_given_complete_state;
 use crate::traits::basic_snippet::BasicSnippet;
 use crate::traits::rust_shadow::RustShadow;
+use crate::traits::rust_shadow::RustShadowError;
 
 /// A trait that can modify all parts of the VM state.
 ///
@@ -39,7 +40,7 @@ pub trait Procedure: BasicSnippet {
         nondeterminism: &NonDeterminism,
         public_input: &[BFieldElement],
         sponge: &mut Option<Tip5>,
-    ) -> Vec<BFieldElement>;
+    ) -> Result<Vec<BFieldElement>, RustShadowError>;
 
     fn preprocess<T: BFieldCodec>(_meta_input: T, _nondeterminism: &mut NonDeterminism) {}
 
@@ -50,7 +51,7 @@ pub trait Procedure: BasicSnippet {
     ) -> ProcedureInitialState;
 
     fn corner_case_initial_states(&self) -> Vec<ProcedureInitialState> {
-        vec![]
+        Vec::new()
     }
 }
 
@@ -95,7 +96,7 @@ impl<P: Procedure> RustShadow for ShadowedProcedure<P> {
         stack: &mut Vec<BFieldElement>,
         memory: &mut HashMap<BFieldElement, BFieldElement>,
         sponge: &mut Option<Tip5>,
-    ) -> Vec<BFieldElement> {
+    ) -> Result<Vec<BFieldElement>, RustShadowError> {
         self.procedure
             .rust_shadow(stack, memory, nondeterminism, stdin, sponge)
     }

--- a/tasm-lib/src/traits/read_only_algorithm.rs
+++ b/tasm-lib/src/traits/read_only_algorithm.rs
@@ -6,6 +6,7 @@ use triton_vm::prelude::*;
 
 use super::basic_snippet::BasicSnippet;
 use super::rust_shadow::RustShadow;
+use super::rust_shadow::RustShadowError;
 use crate::InitVmState;
 use crate::linker::execute_bench;
 use crate::prelude::Tip5;
@@ -35,7 +36,7 @@ pub trait ReadOnlyAlgorithm: BasicSnippet {
         memory: &HashMap<BFieldElement, BFieldElement>,
         nd_tokens: VecDeque<BFieldElement>,
         nd_digests: VecDeque<Digest>,
-    );
+    ) -> Result<(), RustShadowError>;
 
     fn pseudorandom_initial_state(
         &self,
@@ -44,7 +45,7 @@ pub trait ReadOnlyAlgorithm: BasicSnippet {
     ) -> ReadOnlyAlgorithmInitialState;
 
     fn corner_case_initial_states(&self) -> Vec<ReadOnlyAlgorithmInitialState> {
-        vec![]
+        Vec::new()
     }
 }
 
@@ -89,14 +90,15 @@ where
         stack: &mut Vec<BFieldElement>,
         memory: &mut HashMap<BFieldElement, BFieldElement>,
         _sponge: &mut Option<Tip5>,
-    ) -> Vec<BFieldElement> {
+    ) -> Result<Vec<BFieldElement>, RustShadowError> {
         self.algorithm.rust_shadow(
             stack,
             memory,
             nondeterminism.individual_tokens.to_owned().into(),
             nondeterminism.digests.to_owned().into(),
-        );
-        vec![]
+        )?;
+
+        Ok(Vec::new())
     }
 
     fn test(&self) {

--- a/tasm-lib/src/traits/rust_shadow.rs
+++ b/tasm-lib/src/traits/rust_shadow.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-
+use strum::Display;
 use triton_vm::prelude::*;
 
 use crate::prelude::*;
@@ -14,9 +14,34 @@ pub trait RustShadow {
         stack: &mut Vec<BFieldElement>,
         memory: &mut HashMap<BFieldElement, BFieldElement>,
         sponge: &mut Option<Tip5>,
-    ) -> Vec<BFieldElement>;
+    ) -> Result<Vec<BFieldElement>, RustShadowError>;
 
     fn test(&self);
 
     fn bench(&self);
 }
+
+/// Errors that can occur during the execution of the [Rust shadow](RustShadow)
+/// implementation of a snippet.
+#[derive(Debug, Display, Copy, Clone, Eq, PartialEq)]
+pub enum RustShadowError {
+    ArithmeticOverflow,
+    DecodingError,
+    InvalidProof,
+    SpongeUninitialized,
+    StackUnderflow,
+    U64ToU32Error,
+    U64ToUsizeError,
+    UsizeToU32Error,
+    VmError,
+
+    /// Mimics a Triton VM [AssertionError](isa::instruction::AssertionError).
+    ///
+    /// The payload can be used to check error ID equivalence.
+    AssertionError(i128),
+
+    /// An unspecified issue.
+    Other,
+}
+
+impl std::error::Error for RustShadowError {}

--- a/tasm-lib/src/verifier/challenges/new_empty_input_and_output.rs
+++ b/tasm-lib/src/verifier/challenges/new_empty_input_and_output.rs
@@ -166,13 +166,15 @@ mod tests {
         fn rust_shadow(
             &self,
             stack: &mut Vec<BFieldElement>,
-            memory: &mut std::collections::HashMap<BFieldElement, BFieldElement>,
+            memory: &mut HashMap<BFieldElement, BFieldElement>,
             _: &NonDeterminism,
             _: &[BFieldElement],
             sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
-            let sponge = sponge.as_mut().expect("sponge must be initialized");
-            let program_digest = pop_encodable(stack);
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
+            let Some(sponge) = sponge.as_mut() else {
+                return Err(RustShadowError::SpongeUninitialized);
+            };
+            let program_digest = pop_encodable(stack)?;
 
             let claim = Claim::new(program_digest);
             let challenges = sponge.sample_scalars(self.num_of_fiat_shamir_challenges);
@@ -190,7 +192,7 @@ mod tests {
                 challenges.challenges.to_vec(),
             );
 
-            vec![]
+            Ok(Vec::new())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/verifier/challenges/new_empty_input_and_output.rs
+++ b/tasm-lib/src/verifier/challenges/new_empty_input_and_output.rs
@@ -214,7 +214,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn new_challenge_empty_input_output_pbt() {
         const NUM_OF_CLAIM_DERIVED_CHALLENGES: usize = 4;
         ShadowedProcedure::new(NewEmptyInputAndOutput {
@@ -234,7 +234,7 @@ mod benches {
     use crate::test_prelude::*;
     use crate::verifier::challenges::shared;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         const NUM_OF_CLAIM_DERIVED_CHALLENGES: usize = 4;
         ShadowedProcedure::new(NewEmptyInputAndOutput {

--- a/tasm-lib/src/verifier/challenges/new_generic_dyn_claim.rs
+++ b/tasm-lib/src/verifier/challenges/new_generic_dyn_claim.rs
@@ -281,7 +281,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn new_challenges_pbt() {
         ShadowedProcedure::new(NewGenericDynClaim::tvm_challenges(
             conventional_challenges_pointer(),
@@ -296,7 +296,7 @@ mod benches {
     use crate::test_prelude::*;
     use crate::verifier::challenges::shared::conventional_challenges_pointer;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_for_challenges_calc_for_recufier() {
         ShadowedProcedure::new(NewGenericDynClaim::tvm_challenges(
             conventional_challenges_pointer(),

--- a/tasm-lib/src/verifier/challenges/new_generic_dyn_claim.rs
+++ b/tasm-lib/src/verifier/challenges/new_generic_dyn_claim.rs
@@ -231,9 +231,11 @@ mod tests {
             _nondeterminism: &NonDeterminism,
             _public_input: &[BFieldElement],
             sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
-            let sponge = sponge.as_mut().expect("sponge must be initialized");
-            let claim_pointer = stack.pop().unwrap();
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
+            let Some(sponge) = sponge.as_mut() else {
+                return Err(RustShadowError::SpongeUninitialized);
+            };
+            let claim_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
             let claim = load_claim_from_memory(claim_pointer, memory);
             let challenges = sponge.sample_scalars(self.num_of_fiat_shamir_challenges);
             let challenges = Challenges::new(challenges, &claim);
@@ -243,7 +245,7 @@ mod tests {
 
             insert_as_array(challenges_pointer, memory, challenges.challenges.to_vec());
 
-            vec![]
+            Ok(Vec::new())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/verifier/claim/instantiate_fiat_shamir_with_claim.rs
+++ b/tasm-lib/src/verifier/claim/instantiate_fiat_shamir_with_claim.rs
@@ -84,14 +84,17 @@ mod tests {
             _nondeterminism: &NonDeterminism,
             _public_input: &[BFieldElement],
             sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
-            let claim_pointer = stack.pop().unwrap();
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
+            let claim_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
 
             let claim = load_claim_from_memory(claim_pointer, memory);
 
-            sponge.as_mut().unwrap().pad_and_absorb_all(&claim.encode());
+            let Some(sponge) = sponge.as_mut() else {
+                return Err(RustShadowError::SpongeUninitialized);
+            };
+            sponge.pad_and_absorb_all(&claim.encode());
 
-            vec![]
+            Ok(Vec::new())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/verifier/claim/instantiate_fiat_shamir_with_claim.rs
+++ b/tasm-lib/src/verifier/claim/instantiate_fiat_shamir_with_claim.rs
@@ -144,7 +144,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test() {
         ShadowedProcedure::new(InstantiateFiatShamirWithClaim).test();
     }
@@ -155,7 +155,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedProcedure::new(InstantiateFiatShamirWithClaim).bench();
     }

--- a/tasm-lib/src/verifier/claim/new_recursive.rs
+++ b/tasm-lib/src/verifier/claim/new_recursive.rs
@@ -118,7 +118,7 @@ pub mod tests {
     use crate::test_prelude::*;
     use crate::verifier::claim::shared::insert_claim_into_static_memory;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn new_recursive_claim_small_params_pbt() {
         ShadowedProcedure::new(NewRecursive {
             input_size: Digest::LEN,
@@ -127,7 +127,7 @@ pub mod tests {
         .test()
     }
 
-    #[proptest(cases = 10)]
+    #[macro_rules_attr::apply(proptest(cases = 10))]
     fn new_recursive_claim_pbt_pbt(
         #[strategy(0_usize..200)] output_size: usize,
         #[strategy(0_usize..200)] input_size: usize,

--- a/tasm-lib/src/verifier/claim/new_recursive.rs
+++ b/tasm-lib/src/verifier/claim/new_recursive.rs
@@ -147,7 +147,7 @@ pub mod tests {
             nondeterminism: &NonDeterminism,
             _public_input: &[BFieldElement],
             _sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
             println!(
                 "nondeterminism.individual_tokens: {}",
                 nondeterminism.individual_tokens.iter().join(",")
@@ -157,13 +157,19 @@ pub mod tests {
 
             let mut output = vec![];
             for _ in 0..self.output_size {
-                output.push(individual_tokens.pop_front().unwrap());
+                let front_token = individual_tokens
+                    .pop_front()
+                    .ok_or(RustShadowError::StackUnderflow)?;
+                output.push(front_token);
             }
             output.reverse();
 
             let mut input = vec![];
             for _ in 0..self.input_size {
-                input.push(individual_tokens.pop_front().unwrap());
+                let front_token = individual_tokens
+                    .pop_front()
+                    .ok_or(RustShadowError::StackUnderflow)?;
+                input.push(front_token);
             }
             input.reverse();
 
@@ -176,7 +182,7 @@ pub mod tests {
 
             stack.push(claim_pointer);
 
-            vec![]
+            Ok(Vec::new())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/verifier/eval_arg/compute_terminal_const_sized_dynamic_symbols_reversed.rs
+++ b/tasm-lib/src/verifier/eval_arg/compute_terminal_const_sized_dynamic_symbols_reversed.rs
@@ -198,42 +198,42 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn eval_compute_terminal_test_rev_const_sized_1() {
         ShadowedFunction::new(ComputeTerminalConstSizedDynamicSymbolsReversed::<1>).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn eval_compute_terminal_test_rev_const_sized_2() {
         ShadowedFunction::new(ComputeTerminalConstSizedDynamicSymbolsReversed::<2>).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn eval_compute_terminal_test_rev_const_sized_3() {
         ShadowedFunction::new(ComputeTerminalConstSizedDynamicSymbolsReversed::<3>).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn eval_compute_terminal_test_rev_const_sized_4() {
         ShadowedFunction::new(ComputeTerminalConstSizedDynamicSymbolsReversed::<4>).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn eval_compute_terminal_test_rev_const_sized_5() {
         ShadowedFunction::new(ComputeTerminalConstSizedDynamicSymbolsReversed::<5>).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn eval_compute_terminal_test_rev_const_sized_34() {
         ShadowedFunction::new(ComputeTerminalConstSizedDynamicSymbolsReversed::<34>).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn eval_compute_terminal_test_rev_const_sized_64() {
         ShadowedFunction::new(ComputeTerminalConstSizedDynamicSymbolsReversed::<64>).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn eval_compute_terminal_test_rev_const_sized_256() {
         ShadowedFunction::new(ComputeTerminalConstSizedDynamicSymbolsReversed::<256>).test()
     }
@@ -244,7 +244,7 @@ mod bench {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_const_sized_terminal_calc_rev_5() {
         // What's the cost if input is a digest? Does not include code to move digest into
         // memory as an array.
@@ -252,17 +252,17 @@ mod bench {
             .bench()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_const_sized_terminal_calc_rev_30() {
         ShadowedFunction::new(ComputeTerminalConstSizedDynamicSymbolsReversed::<30>).bench()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_const_sized_terminal_calc_rev_100() {
         ShadowedFunction::new(ComputeTerminalConstSizedDynamicSymbolsReversed::<100>).bench()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_const_sized_terminal_calc_rev_256() {
         ShadowedFunction::new(ComputeTerminalConstSizedDynamicSymbolsReversed::<256>).bench()
     }

--- a/tasm-lib/src/verifier/eval_arg/compute_terminal_const_sized_dynamic_symbols_reversed.rs
+++ b/tasm-lib/src/verifier/eval_arg/compute_terminal_const_sized_dynamic_symbols_reversed.rs
@@ -113,17 +113,17 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let symbols_pointer = stack.pop().unwrap();
+        ) -> Result<(), RustShadowError> {
+            let symbols_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
             let initial = XFieldElement::new([
-                stack.pop().unwrap(),
-                stack.pop().unwrap(),
-                stack.pop().unwrap(),
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
             ]);
             let challenge = XFieldElement::new([
-                stack.pop().unwrap(),
-                stack.pop().unwrap(),
-                stack.pop().unwrap(),
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
             ]);
             let mut symbols_elem_pointer = symbols_pointer + BFieldElement::new(N as u64 - 1);
 
@@ -138,6 +138,7 @@ mod tests {
             for elem in result.coefficients.into_iter().rev() {
                 stack.push(elem);
             }
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/verifier/eval_arg/compute_terminal_const_sized_static_symbols.rs
+++ b/tasm-lib/src/verifier/eval_arg/compute_terminal_const_sized_static_symbols.rs
@@ -113,10 +113,11 @@ mod tests {
     impl<const N: usize> Closure for ComputeTerminalConstSizedStaticSymbols<N> {
         type Args = XFieldElement;
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let challenge = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let challenge = pop_encodable::<Self::Args>(stack)?;
             let terminal = EvalArg::compute_terminal(&self.symbols, self.initial, challenge);
             push_encodable(stack, &terminal);
+            Ok(())
         }
 
         fn pseudorandom_args(
@@ -292,7 +293,8 @@ mod tests {
                 &[],
                 NonDeterminism::default(),
                 &None,
-            );
+            )
+            .unwrap();
             let terminal = Literal::pop_from_stack(DataType::Xfe, &mut final_state.op_stack.stack);
 
             terminal.as_xfe()
@@ -324,7 +326,8 @@ mod tests {
             &[],
             NonDeterminism::default(),
             &None,
-        );
+        )
+        .unwrap();
         let terminal = Literal::pop_from_stack(DataType::Xfe, &mut final_state.op_stack.stack);
 
         terminal.as_xfe()
@@ -358,7 +361,8 @@ mod tests {
             &[],
             NonDeterminism::default().with_ram(memory),
             &None,
-        );
+        )
+        .unwrap();
 
         let terminal = Literal::pop_from_stack(DataType::Xfe, &mut final_state.op_stack.stack);
 
@@ -389,7 +393,8 @@ mod tests {
             &[],
             NonDeterminism::default().with_ram(memory),
             &None,
-        );
+        )
+        .unwrap();
 
         let terminal = Literal::pop_from_stack(DataType::Xfe, &mut final_state.op_stack.stack);
 

--- a/tasm-lib/src/verifier/eval_arg/compute_terminal_const_sized_static_symbols.rs
+++ b/tasm-lib/src/verifier/eval_arg/compute_terminal_const_sized_static_symbols.rs
@@ -98,8 +98,6 @@ impl<const N: usize> BasicSnippet for ComputeTerminalConstSizedStaticSymbols<N> 
 mod tests {
     use num::One;
     use num::Zero;
-    use proptest_arbitrary_interop::arb;
-    use test_strategy::proptest;
     use triton_vm::air::cross_table_argument::CrossTableArg;
     use triton_vm::air::cross_table_argument::EvalArg;
 
@@ -130,7 +128,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn eval_compute_unit_test_1() {
         ShadowedClosure::new(ComputeTerminalConstSizedStaticSymbols::<1> {
             symbols: [BFieldElement::new(77)],
@@ -139,7 +137,7 @@ mod tests {
         .test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn eval_compute_unit_test_2() {
         ShadowedClosure::new(ComputeTerminalConstSizedStaticSymbols::<2> {
             symbols: [BFieldElement::new(77), BFieldElement::new(177)],
@@ -148,7 +146,7 @@ mod tests {
         .test();
     }
 
-    #[proptest(cases = 3)]
+    #[macro_rules_attr::apply(proptest(cases = 3))]
     fn eval_compute_terminal_test_1(
         #[strategy(arb())] symbol: BFieldElement,
         #[strategy(arb())] initial: XFieldElement,
@@ -160,7 +158,7 @@ mod tests {
         .test();
     }
 
-    #[proptest(cases = 3)]
+    #[macro_rules_attr::apply(proptest(cases = 3))]
     fn eval_compute_terminal_test_2(
         #[strategy(arb())] symbols: [BFieldElement; 2],
         #[strategy(arb())] initial: XFieldElement,
@@ -169,7 +167,7 @@ mod tests {
             .test();
     }
 
-    #[proptest(cases = 3)]
+    #[macro_rules_attr::apply(proptest(cases = 3))]
     fn eval_compute_terminal_test_3(
         #[strategy(arb())] symbols: [BFieldElement; 3],
         #[strategy(arb())] initial: XFieldElement,
@@ -178,7 +176,7 @@ mod tests {
             .test();
     }
 
-    #[proptest(cases = 3)]
+    #[macro_rules_attr::apply(proptest(cases = 3))]
     fn eval_compute_terminal_test_4(
         #[strategy(arb())] symbols: [BFieldElement; 4],
         #[strategy(arb())] initial: XFieldElement,
@@ -187,7 +185,7 @@ mod tests {
             .test();
     }
 
-    #[proptest(cases = 3)]
+    #[macro_rules_attr::apply(proptest(cases = 3))]
     fn eval_compute_terminal_test_5(
         #[strategy(arb())] symbols: [BFieldElement; 5],
         #[strategy(arb())] initial: XFieldElement,
@@ -196,7 +194,7 @@ mod tests {
             .test();
     }
 
-    #[proptest(cases = 3)]
+    #[macro_rules_attr::apply(proptest(cases = 3))]
     fn eval_compute_terminal_test_256(
         #[strategy(arb())] symbols: [BFieldElement; 256],
         #[strategy(arb())] initial: XFieldElement,
@@ -205,7 +203,7 @@ mod tests {
             .test();
     }
 
-    #[proptest(cases = 3)]
+    #[macro_rules_attr::apply(proptest(cases = 3))]
     fn compare_to_other_implementations_length_1(
         #[strategy(arb())] initial: XFieldElement,
         #[strategy(arb())] challenge: XFieldElement,
@@ -219,7 +217,7 @@ mod tests {
         assert_eq!(stat_res_const_sized, dyn_res_dyn_sized);
     }
 
-    #[proptest(cases = 3)]
+    #[macro_rules_attr::apply(proptest(cases = 3))]
     fn compare_to_other_implementations_length_2(
         #[strategy(arb())] initial: XFieldElement,
         #[strategy(arb())] challenge: XFieldElement,
@@ -233,7 +231,7 @@ mod tests {
         assert_eq!(stat_res_const_sized, dyn_res_dyn_sized);
     }
 
-    #[proptest(cases = 3)]
+    #[macro_rules_attr::apply(proptest(cases = 3))]
     fn compare_to_other_implementations_length_3(
         #[strategy(arb())] initial: XFieldElement,
         #[strategy(arb())] challenge: XFieldElement,
@@ -247,7 +245,7 @@ mod tests {
         assert_eq!(stat_res_const_sized, dyn_res_dyn_sized);
     }
 
-    #[proptest(cases = 3)]
+    #[macro_rules_attr::apply(proptest(cases = 3))]
     fn compare_to_other_implementations_length_4(
         #[strategy(arb())] initial: XFieldElement,
         #[strategy(arb())] challenge: XFieldElement,
@@ -261,7 +259,7 @@ mod tests {
         assert_eq!(stat_res_const_sized, dyn_res_dyn_sized);
     }
 
-    #[proptest(cases = 3)]
+    #[macro_rules_attr::apply(proptest(cases = 3))]
     fn compare_to_other_implementations_length_5(
         #[strategy(arb())] initial: XFieldElement,
         #[strategy(arb())] challenge: XFieldElement,
@@ -275,7 +273,7 @@ mod tests {
         assert_eq!(stat_res_const_sized, dyn_res_dyn_sized);
     }
 
-    #[proptest(cases = 3)]
+    #[macro_rules_attr::apply(proptest(cases = 3))]
     fn compare_to_other_implementations_length_5_initial_is_one(
         #[strategy(arb())] challenge: XFieldElement,
         #[strategy(arb())] symbols: [BFieldElement; 5],
@@ -404,7 +402,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(ComputeTerminalConstSizedStaticSymbols::<256> {
             symbols: bfe_array![100; 256],

--- a/tasm-lib/src/verifier/eval_arg/compute_terminal_dyn_sized_dynamic_symbols.rs
+++ b/tasm-lib/src/verifier/eval_arg/compute_terminal_dyn_sized_dynamic_symbols.rs
@@ -138,17 +138,17 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let symbols_pointer = stack.pop().unwrap();
+        ) -> Result<(), RustShadowError> {
+            let symbols_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
             let initial = XFieldElement::new([
-                stack.pop().unwrap(),
-                stack.pop().unwrap(),
-                stack.pop().unwrap(),
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
             ]);
             let challenge = XFieldElement::new([
-                stack.pop().unwrap(),
-                stack.pop().unwrap(),
-                stack.pop().unwrap(),
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
             ]);
             let mut symbols_elem_pointer =
                 symbols_pointer + BFieldElement::new(LIST_METADATA_SIZE as u64);
@@ -165,6 +165,7 @@ mod tests {
             for elem in result.coefficients.into_iter().rev() {
                 stack.push(elem);
             }
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/verifier/eval_arg/compute_terminal_dyn_sized_dynamic_symbols.rs
+++ b/tasm-lib/src/verifier/eval_arg/compute_terminal_dyn_sized_dynamic_symbols.rs
@@ -255,7 +255,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn eval_compute_terminal_test() {
         ShadowedFunction::new(ComputeTerminalDynSizedDynamicSymbols).test()
     }
@@ -266,7 +266,7 @@ mod bench {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(ComputeTerminalDynSizedDynamicSymbols).bench()
     }

--- a/tasm-lib/src/verifier/eval_arg/compute_terminal_from_digest.rs
+++ b/tasm-lib/src/verifier/eval_arg/compute_terminal_from_digest.rs
@@ -112,7 +112,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedClosure::new(ComputeTerminalFromDigestInitialIsOne).test();
     }
@@ -123,7 +123,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(ComputeTerminalFromDigestInitialIsOne).bench()
     }

--- a/tasm-lib/src/verifier/eval_arg/compute_terminal_from_digest.rs
+++ b/tasm-lib/src/verifier/eval_arg/compute_terminal_from_digest.rs
@@ -100,11 +100,12 @@ mod tests {
     impl Closure for ComputeTerminalFromDigestInitialIsOne {
         type Args = (XFieldElement, Digest);
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (challenge, digest) = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (challenge, digest) = pop_encodable::<Self::Args>(stack)?;
             let terminal =
                 EvalArg::compute_terminal(&digest.0, EvalArg::default_initial(), challenge);
             push_encodable(stack, &terminal);
+            Ok(())
         }
 
         fn pseudorandom_args(&self, seed: [u8; 32], _: Option<BenchmarkCase>) -> Self::Args {

--- a/tasm-lib/src/verifier/fri/barycentric_evaluation.rs
+++ b/tasm-lib/src/verifier/fri/barycentric_evaluation.rs
@@ -232,7 +232,7 @@ mod tests {
     use crate::rust_shadowing_helper_functions::list::load_list_with_copy_elements;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn barycentric_evaluation_pbt() {
         ShadowedFunction::new(BarycentricEvaluation).test()
     }
@@ -355,7 +355,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_barycentric_evaluation() {
         ShadowedFunction::new(BarycentricEvaluation).bench();
     }

--- a/tasm-lib/src/verifier/fri/barycentric_evaluation.rs
+++ b/tasm-lib/src/verifier/fri/barycentric_evaluation.rs
@@ -263,23 +263,29 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
+        ) -> Result<(), RustShadowError> {
             let indeterminate = XFieldElement::new([
-                stack.pop().unwrap(),
-                stack.pop().unwrap(),
-                stack.pop().unwrap(),
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
             ]);
-            let codeword_pointer = stack.pop().unwrap();
+            let codeword_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
             let codeword =
-                load_list_with_copy_elements::<EXTENSION_DEGREE>(codeword_pointer, memory);
-            let codeword_length: u32 = codeword.len().try_into().unwrap();
-            assert!(codeword_length <= MAX_CODEWORD_LENGTH);
+                load_list_with_copy_elements::<EXTENSION_DEGREE>(codeword_pointer, memory)?;
+            let codeword_length: u32 = codeword
+                .len()
+                .try_into()
+                .map_err(|_| RustShadowError::UsizeToU32Error)?;
+            if codeword_length > MAX_CODEWORD_LENGTH {
+                return Err(RustShadowError::Other);
+            }
 
             let codeword: Vec<XFieldElement> = codeword.into_iter().map(|x| x.into()).collect_vec();
             let result = barycentric_evaluate(&codeword, indeterminate);
 
             // Emulate effect on memory
-            let generator = BFieldElement::primitive_root_of_unity(codeword.len() as u64).unwrap();
+            let generator = BFieldElement::primitive_root_of_unity(codeword.len() as u64)
+                .ok_or(RustShadowError::Other)?;
             let mut partial_terms_pointer = STATIC_MEMORY_FIRST_ADDRESS
                 - bfe!(MAX_CODEWORD_LENGTH * EXTENSION_DEGREE as u32 - 1);
             let mut gen_acc = bfe!(1);
@@ -300,6 +306,7 @@ mod tests {
             for word in result.coefficients.into_iter().rev() {
                 stack.push(word);
             }
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/verifier/fri/collinear_y.rs
+++ b/tasm-lib/src/verifier/fri/collinear_y.rs
@@ -140,7 +140,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test() {
         ShadowedClosure::new(CollinearYXfe).test()
     }
@@ -151,7 +151,7 @@ mod bench {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedClosure::new(CollinearYXfe).bench();
     }

--- a/tasm-lib/src/verifier/fri/collinear_y.rs
+++ b/tasm-lib/src/verifier/fri/collinear_y.rs
@@ -129,10 +129,11 @@ mod tests {
             XFieldElement,
         );
 
-        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) {
-            let (p2x, p1y, p1x, p0y, p0x) = pop_encodable::<Self::Args>(stack);
+        fn rust_shadow(&self, stack: &mut Vec<BFieldElement>) -> Result<(), RustShadowError> {
+            let (p2x, p1y, p1x, p0y, p0x) = pop_encodable::<Self::Args>(stack)?;
             let p2y = Polynomial::get_colinear_y((p0x, p0y), (p1x, p1y), p2x);
             push_encodable(stack, &p2y);
+            Ok(())
         }
 
         fn pseudorandom_args(&self, seed: [u8; 32], _: Option<BenchmarkCase>) -> Self::Args {

--- a/tasm-lib/src/verifier/fri/collinearity_check_x.rs
+++ b/tasm-lib/src/verifier/fri/collinearity_check_x.rs
@@ -70,14 +70,15 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
+        ) -> Result<(), RustShadowError> {
             // read stack arguments
-            let round = stack.pop().unwrap().value() as usize;
-            let index = stack.pop().unwrap().value() as u32;
-            let fri_verify_address = stack.pop().unwrap();
+            let round = stack.pop().ok_or(RustShadowError::StackUnderflow)?.value() as usize;
+            let index = stack.pop().ok_or(RustShadowError::StackUnderflow)?.value() as u32;
+            let fri_verify_address = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
 
             // read fri_verify object from memory
-            let fri_verify = FriVerify::decode_from_memory(memory, fri_verify_address).unwrap();
+            let fri_verify = FriVerify::decode_from_memory(memory, fri_verify_address)
+                .map_err(|_| RustShadowError::DecodingError)?;
 
             // invoke actual function
             let x = fri_verify.get_collinearity_check_x(index, round);
@@ -86,6 +87,7 @@ mod tests {
             stack.push(x.coefficients[2]);
             stack.push(x.coefficients[1]);
             stack.push(x.coefficients[0]);
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/verifier/fri/collinearity_check_x.rs
+++ b/tasm-lib/src/verifier/fri/collinearity_check_x.rs
@@ -127,7 +127,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test() {
         ShadowedFunction::new(GetCollinearityCheckX).test();
     }
@@ -138,7 +138,7 @@ mod bench {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench() {
         ShadowedFunction::new(GetCollinearityCheckX).bench();
     }

--- a/tasm-lib/src/verifier/fri/derive_from_stark.rs
+++ b/tasm-lib/src/verifier/fri/derive_from_stark.rs
@@ -114,6 +114,7 @@ impl BasicSnippet for DeriveFriFromStark {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::U32_TO_USIZE_ERR;
     use crate::rust_shadowing_helper_functions;
     use crate::test_prelude::*;
     use crate::verifier::fri::verify::FriVerify;
@@ -136,14 +137,23 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let padded_height: u32 = stack.pop().unwrap().try_into().unwrap();
-            let fri_from_tvm = self.stark.fri(padded_height.try_into().unwrap()).unwrap();
+        ) -> Result<(), RustShadowError> {
+            let padded_height: u32 = stack
+                .pop()
+                .ok_or(RustShadowError::StackUnderflow)?
+                .try_into()
+                .map_err(|_| RustShadowError::U64ToU32Error)?;
+            let fri_from_tvm = self
+                .stark
+                .fri(padded_height.try_into().expect(U32_TO_USIZE_ERR))
+                .map_err(|_| RustShadowError::Other)?;
             let local_fri: FriVerify = fri_from_tvm.into();
             let fri_pointer =
                 rust_shadowing_helper_functions::dyn_malloc::dynamic_allocator(memory);
             encode_to_memory(memory, fri_pointer, &local_fri);
-            stack.push(fri_pointer)
+            stack.push(fri_pointer);
+
+            Ok(())
         }
 
         fn pseudorandom_initial_state(
@@ -151,12 +161,28 @@ mod tests {
             seed: [u8; 32],
             bench_case: Option<BenchmarkCase>,
         ) -> FunctionInitialState {
+            // Due to an arithmetic-overflow bug in Triton VM v3.0.0, derivation
+            // of a FRI instance using values that are too close to `usize::MAX`
+            // (and what “too close” means depends on the FRI expansion factor)
+            // results in a `panic!`, not an `Err`. The workaround is not pretty
+            // but should be temporary.
+
+            #[cfg(target_pointer_width = "32")]
+            const WORST_CASE_BENCH_SIZE: u32 = 21;
+            #[cfg(target_pointer_width = "64")]
+            const WORST_CASE_BENCH_SIZE: u32 = 23;
+
+            #[cfg(target_pointer_width = "32")]
+            const MAX_BENCH_SIZE: u32 = WORST_CASE_BENCH_SIZE;
+            #[cfg(target_pointer_width = "64")]
+            const MAX_BENCH_SIZE: u32 = 25;
+
             let padded_height: u32 = match bench_case {
                 Some(BenchmarkCase::CommonCase) => 2u32.pow(21),
-                Some(BenchmarkCase::WorstCase) => 2u32.pow(23),
+                Some(BenchmarkCase::WorstCase) => 2u32.pow(WORST_CASE_BENCH_SIZE),
                 None => {
                     let mut rng = StdRng::from_seed(seed);
-                    let mut padded_height = 2u32.pow(rng.random_range(8..=25));
+                    let mut padded_height = 2u32.pow(rng.random_range(8..=MAX_BENCH_SIZE));
 
                     // Don't test parameters that result in too big FRI domains, i.e. larger
                     // than 2^32. Note that this also excludes 2^32 as domain length because

--- a/tasm-lib/src/verifier/fri/derive_from_stark.rs
+++ b/tasm-lib/src/verifier/fri/derive_from_stark.rs
@@ -118,7 +118,7 @@ mod tests {
     use crate::test_prelude::*;
     use crate::verifier::fri::verify::FriVerify;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn fri_param_derivation_default_stark_pbt() {
         ShadowedFunction::new(DeriveFriFromStark {
             stark: Stark::default(),
@@ -126,7 +126,7 @@ mod tests {
         .test();
     }
 
-    #[proptest(cases = 10)]
+    #[macro_rules_attr::apply(proptest(cases = 10))]
     fn fri_param_derivation_pbt_pbt(#[strategy(arb())] stark: Stark) {
         ShadowedFunction::new(DeriveFriFromStark { stark }).test();
     }

--- a/tasm-lib/src/verifier/fri/number_of_rounds.rs
+++ b/tasm-lib/src/verifier/fri/number_of_rounds.rs
@@ -113,12 +113,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_shadow() {
         ShadowedFunction::new(NumberOfRounds {}).test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn shadow_agrees_with_canon() {
         let mut rng = rand::rng();
         let num_trials = 50;

--- a/tasm-lib/src/verifier/fri/number_of_rounds.rs
+++ b/tasm-lib/src/verifier/fri/number_of_rounds.rs
@@ -76,9 +76,14 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let fri_verify = FriVerify::decode_from_memory(memory, stack.pop().unwrap()).unwrap();
+        ) -> Result<(), RustShadowError> {
+            let fri_verify = FriVerify::decode_from_memory(
+                memory,
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
+            )
+            .map_err(|_| RustShadowError::DecodingError)?;
             stack.push(BFieldElement::new(fri_verify.num_rounds() as u64));
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/verifier/fri/standalone_fri_verify.rs
+++ b/tasm-lib/src/verifier/fri/standalone_fri_verify.rs
@@ -100,11 +100,11 @@ impl CompiledProgram for StandaloneFriVerify {
 #[cfg(test)]
 mod bench {
     use super::*;
-    use crate::snippet_bencher::BenchmarkCase;
+    use crate::test_prelude::*;
     use crate::traits::compiled_program::bench_and_profile_program;
 
     #[ignore = "Very slow, about 340s on my powerful laptop"]
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         let public_input = PublicInput::default();
         let intermediate_state = StandaloneFriVerify::singleton().pseudorandom_intermediate_state();

--- a/tasm-lib/src/verifier/fri/verify.rs
+++ b/tasm-lib/src/verifier/fri/verify.rs
@@ -1149,7 +1149,6 @@ impl FriVerify {
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
-    use std::panic::catch_unwind;
 
     use num_traits::Zero;
     use proptest::collection::vec;
@@ -1219,9 +1218,14 @@ mod tests {
     }
 
     impl FriSnippet {
-        /// Test helper – panics if verification fails.
-        fn verify_from_proof_with_digests(&self, proof: Vec<BFieldElement>, digests: Vec<Digest>) {
-            let items = *Vec::<ProofItem>::decode(&proof).unwrap();
+        /// Test helper – errors if verification fails.
+        fn verify_from_proof_with_digests(
+            &self,
+            proof: Vec<BFieldElement>,
+            digests: Vec<Digest>,
+        ) -> Result<(), RustShadowError> {
+            let items =
+                *Vec::<ProofItem>::decode(&proof).map_err(|_| RustShadowError::DecodingError)?;
             let proof_stream = ProofStream {
                 items,
                 items_index: 0,
@@ -1237,7 +1241,9 @@ mod tests {
                 &[],
                 nondeterminism,
                 &Some(Tip5::init()),
-            );
+            )?;
+
+            Ok(())
         }
 
         fn set_up_stack_and_non_determinism(
@@ -1289,16 +1295,21 @@ mod tests {
             nondeterminism: &NonDeterminism,
             _public_input: &[BFieldElement],
             sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
-            let fri_pointer = stack.pop().unwrap();
-            let fri_verify = *FriVerify::decode_from_memory(memory, fri_pointer).unwrap();
-            assert_eq!(fri_verify, self.test_instance);
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
+            let fri_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let fri_verify = *FriVerify::decode_from_memory(memory, fri_pointer)
+                .map_err(|_| RustShadowError::DecodingError)?;
+            if fri_verify != self.test_instance {
+                return Err(RustShadowError::Other);
+            }
 
-            let proof_iter_pointer = stack.pop().unwrap();
+            let proof_iter_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
 
             // uses highly specific knowledge about `BFieldCodec` and the test setup
-            let proof_stream_pointer =
-                *memory.get(&proof_iter_pointer).unwrap() - BFieldElement::new(2);
+            let mem_value = *memory
+                .get(&proof_iter_pointer)
+                .ok_or(RustShadowError::DecodingError)?;
+            let proof_stream_pointer = mem_value - BFieldElement::new(2);
             // todo: hack using local knowledge: `fri_verify` lives directly after `vm_proof_iter`.
             //  Replace this once we have a better way to decode.
             let proof_stream_size = (fri_pointer - proof_stream_pointer).value() as usize;
@@ -1307,7 +1318,7 @@ mod tests {
                 proof_stream_pointer,
                 proof_stream_size,
             )
-            .unwrap();
+            .map_err(|_| RustShadowError::DecodingError)?;
 
             let revealed_indices_and_elements = fri_verify.call(&mut proof_stream, nondeterminism);
 
@@ -1323,7 +1334,7 @@ mod tests {
             *sponge = Some(proof_stream.sponge);
 
             // no standard output
-            vec![]
+            Ok(Vec::new())
         }
 
         fn pseudorandom_initial_state(
@@ -1517,7 +1528,8 @@ mod tests {
             &stdin,
             nondeterminism,
             &sponge,
-        );
+        )
+        .unwrap();
 
         assert_eq!(rust.public_output, tasm.public_output);
         verify_stack_growth(&shadowed_procedure, &initial_stack, &tasm.op_stack.stack);
@@ -1590,7 +1602,9 @@ mod tests {
         let snippet = FriSnippet {
             test_instance: test_case.fri_verify,
         };
-        snippet.verify_from_proof_with_digests(proof.clone(), digests.clone());
+        snippet
+            .verify_from_proof_with_digests(proof.clone(), digests.clone())
+            .unwrap();
 
         let proof_len = proof.len();
         (0..proof_len).into_par_iter().for_each(|i| {
@@ -1599,7 +1613,8 @@ mod tests {
             }
             let mut proof = proof.clone();
             proof[i].increment();
-            catch_unwind(|| snippet.verify_from_proof_with_digests(proof, digests.clone()))
+            snippet
+                .verify_from_proof_with_digests(proof, digests.clone())
                 .expect_err(&format!(
                     "Verification must fail, but succeeded at element {i}/{proof_len}"
                 ));
@@ -1626,7 +1641,8 @@ mod tests {
             &stdin,
             nondeterminism,
             &sponge,
-        );
+        )
+        .unwrap();
 
         assert!(tasm.secret_digests.is_empty());
     }

--- a/tasm-lib/src/verifier/fri/verify.rs
+++ b/tasm-lib/src/verifier/fri/verify.rs
@@ -1154,7 +1154,6 @@ mod tests {
     use num_traits::Zero;
     use proptest::collection::vec;
     use rayon::prelude::*;
-    use test_strategy::proptest;
     use triton_vm::proof_item::ProofItem;
     use twenty_first::math::ntt::ntt;
     use twenty_first::util_types::sponge::Sponge;
@@ -1344,7 +1343,7 @@ mod tests {
         }
     }
 
-    #[derive(Debug, Clone, test_strategy::Arbitrary)]
+    #[derive(Debug, Clone, Arbitrary)]
     struct ArbitraryFriVerify {
         #[strategy(arb())]
         #[filter(!#offset.is_zero())]
@@ -1373,7 +1372,7 @@ mod tests {
         }
     }
 
-    #[derive(Debug, Clone, test_strategy::Arbitrary)]
+    #[derive(Debug, Clone, Arbitrary)]
     pub(super) struct TestCase {
         #[strategy(any::<ArbitraryFriVerify>().prop_map(|x| x.fri_verify()))]
         pub(super) fri_verify: FriVerify,
@@ -1481,7 +1480,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn assert_behavioral_equivalence_of_tiny_fri_instance() {
         assert_behavioral_equivalence_of_fris(TestCase::tiny_case());
     }
@@ -1532,7 +1531,7 @@ mod tests {
         assert_eq!(rust_object, tasm_object);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn fri_derived_params_match(test_case: ArbitraryFriVerify) {
         let fri_verify = test_case.fri_verify();
         let fri = fri_verify.to_fri();
@@ -1548,7 +1547,7 @@ mod tests {
         );
     }
 
-    #[proptest(cases = 10)]
+    #[macro_rules_attr::apply(proptest(cases = 10))]
     fn test_inner_verify(test_case: TestCase) {
         let fri = test_case.fri();
         let mut vm_proof_iter = test_case.proof_stream();
@@ -1561,17 +1560,17 @@ mod tests {
         prop_assert!(verify_result.is_ok(), "FRI verify error: {verify_result:?}");
     }
 
-    #[proptest(cases = 3)]
+    #[macro_rules_attr::apply(proptest(cases = 3))]
     fn test_shadow_prop(test_case: TestCase) {
         assert_behavioral_equivalence_of_fris(test_case);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test_shadow_small() {
         assert_behavioral_equivalence_of_fris(TestCase::small_case());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn modifying_any_element_in_vm_proof_iter_of_small_test_case_causes_verification_failure() {
         let test_case = TestCase::small_case();
         let fri_verify = test_case.fri_verify;
@@ -1607,7 +1606,7 @@ mod tests {
         });
     }
 
-    #[proptest(cases = 2)]
+    #[macro_rules_attr::apply(proptest(cases = 2))]
     fn assert_nondeterministic_digests_are_all_used(test_case: TestCase) {
         let ProcedureInitialState {
             stack: initial_stack,
@@ -1648,7 +1647,7 @@ mod bench {
     use crate::test_prelude::*;
     use crate::verifier::fri::verify::tests::TestCase;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench() {
         let expansion_factor = 4;
         let domain_length = 1 << 10;
@@ -1667,7 +1666,7 @@ mod bench {
     }
 
     #[ignore = "Takes many minutes to run"]
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn profile_fri() {
         const INNER_PADDED_HEIGHTS: [usize; 4] = [1 << 8, 1 << 9, 1 << 10, 1 << 11];
         const SECURITY_LEVEL: usize = 160;

--- a/tasm-lib/src/verifier/fri/verify_fri_authentication_paths.rs
+++ b/tasm-lib/src/verifier/fri/verify_fri_authentication_paths.rs
@@ -340,12 +340,12 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test() {
         ShadowedAlgorithm::new(VerifyFriAuthenticationPaths).test();
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn fri_authentication_fails_if_root_is_disturbed_slightly(
         seed: [u8; 32],
         #[strategy(0_usize..5)] perturbation_index: usize,
@@ -362,7 +362,7 @@ mod tests {
         );
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn fri_authentication_fails_if_xor_bitflag_is_disturbed_slightly(seed: [u8; 32]) {
         let mut initial_state = VerifyFriAuthenticationPaths.pseudorandom_initial_state(seed, None);
         let top_of_stack = initial_state.stack.len() - 1;
@@ -377,7 +377,7 @@ mod tests {
         );
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn fri_authentication_fails_if_authentication_path_is_disturbed_slightly(
         seed: [u8; 32],
         digest_index: usize,
@@ -397,7 +397,7 @@ mod tests {
         );
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn fri_authentication_fails_if_a_index_is_disturbed_slightly(
         seed: [u8; 32],
         perturbation_index: usize,
@@ -440,7 +440,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedAlgorithm::new(VerifyFriAuthenticationPaths).bench();
     }

--- a/tasm-lib/src/verifier/fri/verify_fri_authentication_paths.rs
+++ b/tasm-lib/src/verifier/fri/verify_fri_authentication_paths.rs
@@ -49,7 +49,7 @@ impl BasicSnippet for VerifyFriAuthenticationPaths {
         "tasmlib_verifier_fri_verify_fri_authentication_paths".into()
     }
 
-    fn code(&self, _library: &mut crate::library::Library) -> Vec<LabelledInstruction> {
+    fn code(&self, _library: &mut Library) -> Vec<LabelledInstruction> {
         let entrypoint = self.entrypoint();
         let main_loop = format!("{entrypoint}_main_loop");
 
@@ -145,7 +145,7 @@ mod tests {
     }
 
     impl Distribution<IndexType> for StandardUniform {
-        fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> IndexType {
+        fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> IndexType {
             if rng.random() {
                 IndexType::A
             } else {
@@ -160,13 +160,13 @@ mod tests {
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
             nondeterminism: &NonDeterminism,
-        ) {
-            let root = pop_encodable(stack);
-            let idx_last_elem = pop_encodable(stack);
-            let idx_end_condition = pop_encodable(stack);
-            let leaf_last_element_pointer = pop_encodable(stack);
-            let xor_bitflag = pop_encodable::<u32>(stack);
-            let dom_len_minus_one = pop_encodable::<u32>(stack);
+        ) -> Result<(), RustShadowError> {
+            let root = pop_encodable(stack)?;
+            let idx_last_elem = pop_encodable(stack)?;
+            let idx_end_condition = pop_encodable(stack)?;
+            let leaf_last_element_pointer = pop_encodable(stack)?;
+            let xor_bitflag = pop_encodable::<u32>(stack)?;
+            let dom_len_minus_one = pop_encodable::<u32>(stack)?;
 
             let dom_len = dom_len_minus_one + 1;
             let tree_height = dom_len.ilog2();
@@ -186,7 +186,7 @@ mod tests {
                     .map(|x| x.value())
                     .unwrap_or_default()
                     .try_into()
-                    .unwrap();
+                    .map_err(|_| RustShadowError::U64ToU32Error)?;
                 let node_index = (leaf_index_a_round_0 & dom_len_minus_one) ^ xor_bitflag;
                 let leaf_index = node_index ^ dom_len;
 
@@ -202,12 +202,15 @@ mod tests {
                     indexed_leafs: vec![(leaf_index as usize, leaf.into())],
                     authentication_structure: authentication_path,
                 };
-                assert!(inclusion_proof.verify(root));
+                if !inclusion_proof.verify(root) {
+                    return Err(RustShadowError::InvalidProof);
+                }
 
                 idx_element_pointer.decrement();
                 auth_path_counter += 1;
                 leaf_pointer -= bfe!(EXTENSION_DEGREE as u64);
             }
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/verifier/master_table/air_constraint_evaluation.rs
+++ b/tasm-lib/src/verifier/master_table/air_constraint_evaluation.rs
@@ -430,7 +430,7 @@ mod tests {
             &self,
             _: &mut Vec<BFieldElement>,
             _: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
+        ) -> Result<(), RustShadowError> {
             // Never called as we do a more manual test.
             // The more manual test is done bc we don't want to
             // have to simulate all the intermediate calculations
@@ -621,7 +621,8 @@ mod tests {
                 vec![],
                 NonDeterminism::default().with_ram(init_memory),
                 None,
-            );
+            )
+            .unwrap();
 
             Self::read_result_from_memory(final_state)
         }

--- a/tasm-lib/src/verifier/master_table/air_constraint_evaluation.rs
+++ b/tasm-lib/src/verifier/master_table/air_constraint_evaluation.rs
@@ -307,13 +307,13 @@ mod tests {
     use crate::structure::tasm_object::decode_from_memory_with_size;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn conventional_air_constraint_memory_layouts_are_integral() {
         assert!(MemoryLayout::conventional_static().is_integral());
         assert!(MemoryLayout::conventional_dynamic().is_integral());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn disallow_using_kmalloc_region() {
         let mem_layout = MemoryLayout::Dynamic(DynamicTasmConstraintEvaluationMemoryLayout {
             free_mem_page_ptr: STATIC_MEMORY_LAST_ADDRESS,
@@ -322,7 +322,7 @@ mod tests {
         assert!(!mem_layout.is_integral());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn disallow_using_dynmalloc_region() {
         let mem_layout = MemoryLayout::Dynamic(DynamicTasmConstraintEvaluationMemoryLayout {
             free_mem_page_ptr: BFieldElement::new(42 * (1u64 << 32)),
@@ -331,7 +331,7 @@ mod tests {
         assert!(!mem_layout.is_integral());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn disallow_using_dynmalloc_state() {
         let mem_layout = MemoryLayout::Dynamic(DynamicTasmConstraintEvaluationMemoryLayout {
             free_mem_page_ptr: BFieldElement::new(42 * (1u64 << 32)),
@@ -340,7 +340,7 @@ mod tests {
         assert!(!mem_layout.is_integral());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn disallow_overlapping_regions() {
         let mut dyn_memory_layout = DynamicTasmConstraintEvaluationMemoryLayout {
             free_mem_page_ptr: BFieldElement::new((u32::MAX as u64 - 100) * (1u64 << 32)),
@@ -352,7 +352,7 @@ mod tests {
         assert!(!MemoryLayout::Dynamic(dyn_memory_layout).is_integral());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn conventional_memory_layout_agrees_with_tvm_proof_stored_at_address_zero() {
         let program = triton_program!(halt);
         let claim = Claim::about_program(&program);
@@ -452,7 +452,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraint_evaluation_test() {
         let static_snippet = AirConstraintEvaluation {
             memory_layout: MemoryLayout::Static(an_integral_but_profane_static_memory_layout()),
@@ -633,7 +633,7 @@ mod bench {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_air_constraint_evaluation() {
         ShadowedFunction::new(AirConstraintEvaluation {
             memory_layout: MemoryLayout::Static(an_integral_but_profane_static_memory_layout()),

--- a/tasm-lib/src/verifier/master_table/divide_out_zerofiers.rs
+++ b/tasm-lib/src/verifier/master_table/divide_out_zerofiers.rs
@@ -157,8 +157,9 @@ mod tests {
     use super::*;
     use crate::empty_stack;
     use crate::execute_test;
+    use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn divide_out_zerofiers_test() {
         let snippet = DivideOutZerofiers;
         let mut seed: [u8; 32] = [0u8; 32];
@@ -336,7 +337,7 @@ mod bench {
     use crate::empty_stack;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bench_divide_out_zerofiers() {
         ShadowedFunction::new(DivideOutZerofiers).bench();
     }

--- a/tasm-lib/src/verifier/master_table/divide_out_zerofiers.rs
+++ b/tasm-lib/src/verifier/master_table/divide_out_zerofiers.rs
@@ -260,7 +260,8 @@ mod tests {
                 vec![],
                 NonDeterminism::default().with_ram(memory),
                 None,
-            );
+            )
+            .unwrap();
 
             // read the array pointed to by the pointer living on top of the stack
             AirConstraintEvaluation::read_result_from_memory(final_state).0
@@ -347,7 +348,7 @@ mod bench {
             &self,
             _: &mut Vec<BFieldElement>,
             _: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
+        ) -> Result<(), RustShadowError> {
             // Never called as we do a more manual test.
             // The more manual test is done bc we don't want to
             // have to simulate all the intermediate calculations

--- a/tasm-lib/src/verifier/master_table/verify_table_rows.rs
+++ b/tasm-lib/src/verifier/master_table/verify_table_rows.rs
@@ -280,8 +280,8 @@ mod tests {
             memory: &mut HashMap<BFieldElement, BFieldElement>,
             nondeterminism: &NonDeterminism,
             _public_input: &[BFieldElement],
-            sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
+            sponge_arg: &mut Option<Tip5>,
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
             fn verify_one_row(
                 leaf_index: u32,
                 merkle_root: Digest,
@@ -289,7 +289,7 @@ mod tests {
                 authentication_path: Vec<Digest>,
                 row: &[BFieldElement],
                 sponge: &mut Tip5,
-            ) {
+            ) -> Result<(), RustShadowError> {
                 // We define a local hash_varlen to be able to simulate what happens to the sponge,
                 // as this is required by the test framework.
                 fn local_hash_varlen(input: &[BFieldElement], sponge: &mut Tip5) -> Digest {
@@ -307,40 +307,60 @@ mod tests {
                     authentication_structure: authentication_path,
                 };
 
-                assert!(merkle_tree_inclusion_proof.verify(merkle_root));
+                merkle_tree_inclusion_proof
+                    .verify(merkle_root)
+                    .then_some(())
+                    .ok_or(RustShadowError::InvalidProof)
             }
 
-            *sponge = Some(Tip5::init());
-            let table_rows_pointer = stack.pop().unwrap();
-            let fri_revealed_pointer = stack.pop().unwrap();
-            let merkle_tree_root_pointer = stack.pop().unwrap();
-            let merkle_tree_height: u32 = stack.pop().unwrap().try_into().unwrap();
-            let num_combination_codeword_checks: u32 = stack.pop().unwrap().try_into().unwrap();
+            let table_rows_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let fri_revealed_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let merkle_tree_root_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let merkle_tree_height: u32 = stack
+                .pop()
+                .ok_or(RustShadowError::StackUnderflow)?
+                .try_into()
+                .map_err(|_| RustShadowError::U64ToU32Error)?;
+            let num_combination_codeword_checks: u32 = stack
+                .pop()
+                .ok_or(RustShadowError::StackUnderflow)?
+                .try_into()
+                .map_err(|_| RustShadowError::U64ToU32Error)?;
 
-            let merkle_root = Digest::new(
-                (0..Digest::LEN)
-                    .map(|i| memory[&(merkle_tree_root_pointer + bfe!(i as u32))])
-                    .collect_vec()
-                    .try_into()
-                    .unwrap(),
-            );
+            let merkle_root_innards = (0..Digest::LEN)
+                .map(|i| {
+                    memory
+                        .get(&(merkle_tree_root_pointer + bfe!(i as u32)))
+                        .ok_or(RustShadowError::DecodingError)
+                        .copied()
+                })
+                .try_collect::<_, Vec<_>, _>()?;
+            let merkle_root = Digest::new(merkle_root_innards.try_into().unwrap());
 
             // Verify all rows
+            let mut sponge = Tip5::init();
             let mut j = 0;
             for i in 0..num_combination_codeword_checks {
                 // Read a row from memory
-                let row = (0..self.row_size())
+                let row: Vec<_> = (0..self.row_size())
                     .map(|l| {
-                        memory[&(table_rows_pointer
-                            + bfe!(l as u64 + 1 + (self.row_size() as u64) * i as u64))]
+                        let word_pointer = table_rows_pointer
+                            + bfe!(l as u64 + 1 + (self.row_size() as u64) * i as u64);
+                        memory
+                            .get(&word_pointer)
+                            .copied()
+                            .ok_or(RustShadowError::DecodingError)
                     })
-                    .collect_vec();
+                    .try_collect()?;
 
                 // Read leaf index as provided by the FRI verifier
-                let leaf_index: u32 = nondeterminism.ram
-                    [&(fri_revealed_pointer + bfe!(4) + BFieldElement::new(i as u64 * 4))]
+                let leaf_index: u32 = nondeterminism
+                    .ram
+                    .get(&(fri_revealed_pointer + bfe!(4) + BFieldElement::new(i as u64 * 4)))
+                    .copied()
+                    .ok_or(RustShadowError::DecodingError)?
                     .try_into()
-                    .unwrap();
+                    .map_err(|_| RustShadowError::U64ToU32Error)?;
                 let mut authentication_path = vec![];
                 for _ in 0..merkle_tree_height {
                     authentication_path.push(nondeterminism.digests[j]);
@@ -353,11 +373,12 @@ mod tests {
                     merkle_tree_height,
                     authentication_path,
                     &row,
-                    sponge.as_mut().unwrap(),
-                )
+                    &mut sponge,
+                )?;
             }
+            *sponge_arg = Some(sponge);
 
-            vec![]
+            Ok(Vec::new())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/verifier/master_table/verify_table_rows.rs
+++ b/tasm-lib/src/verifier/master_table/verify_table_rows.rs
@@ -211,7 +211,7 @@ mod tests {
     use crate::rust_shadowing_helper_functions::list::list_insert;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn verify_table_pbt_main() {
         ShadowedProcedure::new(VerifyTableRows {
             column_type: ColumnType::Main,
@@ -219,7 +219,7 @@ mod tests {
         .test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn verify_table_pbt_aux() {
         ShadowedProcedure::new(VerifyTableRows {
             column_type: ColumnType::Aux,
@@ -227,7 +227,7 @@ mod tests {
         .test()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn verify_table_pbt_quot() {
         ShadowedProcedure::new(VerifyTableRows {
             column_type: ColumnType::Quotient,
@@ -238,11 +238,10 @@ mod tests {
     mod negative_tests {
         use strum::IntoEnumIterator;
         use tasm_lib::test_helpers::test_assertion_failure;
-        use test_strategy::proptest;
 
         use super::*;
 
-        #[proptest(cases = 50)]
+        #[macro_rules_attr::apply(proptest(cases = 50))]
         fn verify_bad_auth_path_crashes_vm(seed: [u8; 32]) {
             let mut rng = StdRng::from_seed(seed);
             let snippets = ColumnType::iter().map(|column_type| VerifyTableRows { column_type });
@@ -256,7 +255,7 @@ mod tests {
             }
         }
 
-        #[proptest(cases = 50)]
+        #[macro_rules_attr::apply(proptest(cases = 50))]
         fn verify_bad_row_list_length(seed: [u8; 32]) {
             let snippets = ColumnType::iter().map(|column_type| VerifyTableRows { column_type });
             for snippet in snippets {
@@ -451,7 +450,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn verify_table_bench_main() {
         ShadowedProcedure::new(VerifyTableRows {
             column_type: ColumnType::Main,
@@ -459,7 +458,7 @@ mod benches {
         .bench()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn verify_table_bench_aux() {
         ShadowedProcedure::new(VerifyTableRows {
             column_type: ColumnType::Aux,
@@ -467,7 +466,7 @@ mod benches {
         .bench()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn verify_table_bench_quot() {
         ShadowedProcedure::new(VerifyTableRows {
             column_type: ColumnType::Quotient,

--- a/tasm-lib/src/verifier/master_table/zerofiers_inverse.rs
+++ b/tasm-lib/src/verifier/master_table/zerofiers_inverse.rs
@@ -197,13 +197,18 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let trace_domain_generator = stack.pop().unwrap();
-            let padded_height: u32 = stack.pop().unwrap().value().try_into().unwrap();
+        ) -> Result<(), RustShadowError> {
+            let trace_domain_generator = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let padded_height: u32 = stack
+                .pop()
+                .ok_or(RustShadowError::StackUnderflow)?
+                .value()
+                .try_into()
+                .map_err(|_| RustShadowError::U64ToU32Error)?;
             let out_of_domain_point_curr_row = XFieldElement::new([
-                stack.pop().unwrap(),
-                stack.pop().unwrap(),
-                stack.pop().unwrap(),
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
             ]);
             let initial_zerofier_inv =
                 (out_of_domain_point_curr_row - BFieldElement::one()).inverse();
@@ -224,6 +229,7 @@ mod tests {
                     terminal_zerofier_inv,
                 ],
             );
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/verifier/master_table/zerofiers_inverse.rs
+++ b/tasm-lib/src/verifier/master_table/zerofiers_inverse.rs
@@ -182,7 +182,7 @@ mod tests {
     use crate::rust_shadowing_helper_functions::array::insert_as_array;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn zerofiers_inverse_pbt() {
         let mem_address_if_first_static_malloc =
             -BFieldElement::new(ZerofiersInverse::array_size() as u64) - BFieldElement::one();

--- a/tasm-lib/src/verifier/out_of_domain_points.rs
+++ b/tasm-lib/src/verifier/out_of_domain_points.rs
@@ -142,19 +142,21 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
+        ) -> Result<(), RustShadowError> {
             let ood_curr_row = XFieldElement::new([
-                stack.pop().unwrap(),
-                stack.pop().unwrap(),
-                stack.pop().unwrap(),
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?,
             ]);
-            let domain_generator = stack.pop().unwrap();
+            let domain_generator = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
             let ood_next_row = ood_curr_row * domain_generator;
-            let ood_curr_row_pow_num_segments =
-                ood_curr_row.mod_pow_u32(NUM_QUOTIENT_SEGMENTS.try_into().unwrap());
+            let num_quotient_segments: u32 = NUM_QUOTIENT_SEGMENTS
+                .try_into()
+                .map_err(|_| RustShadowError::UsizeToU32Error)?;
+            let ood_curr_row_pow_num_segments = ood_curr_row.mod_pow_u32(num_quotient_segments);
             let static_malloc_size: i32 = (EXTENSION_DEGREE * NUM_OF_OUT_OF_DOMAIN_POINTS)
                 .try_into()
-                .unwrap();
+                .map_err(|_| RustShadowError::Other)?;
             let ood_points_pointer = bfe!(-static_malloc_size - 1);
             insert_as_array(
                 ood_points_pointer,
@@ -162,7 +164,9 @@ mod tests {
                 vec![ood_curr_row, ood_next_row, ood_curr_row_pow_num_segments],
             );
 
-            stack.push(ood_points_pointer)
+            stack.push(ood_points_pointer);
+
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/verifier/out_of_domain_points.rs
+++ b/tasm-lib/src/verifier/out_of_domain_points.rs
@@ -132,7 +132,7 @@ mod tests {
     use crate::rust_shadowing_helper_functions::array::insert_as_array;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn ood_points_pbt() {
         ShadowedFunction::new(OutOfDomainPoints).test();
     }
@@ -205,7 +205,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(OutOfDomainPoints).bench();
     }

--- a/tasm-lib/src/verifier/own_program_digest.rs
+++ b/tasm-lib/src/verifier/own_program_digest.rs
@@ -42,6 +42,7 @@ impl BasicSnippet for OwnProgramDigest {
 mod tests {
     use super::*;
     use crate::execute_with_terminal_state;
+    use crate::test_prelude::*;
 
     #[derive(Debug, Clone, Eq, PartialEq)]
     struct ProgramSetup {
@@ -63,7 +64,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn positive_test() {
         let test_setup = test_program();
 

--- a/tasm-lib/src/verifier/read_and_verify_own_program_digest_from_std_in.rs
+++ b/tasm-lib/src/verifier/read_and_verify_own_program_digest_from_std_in.rs
@@ -45,6 +45,7 @@ impl BasicSnippet for ReadAndVerifyOwnProgramDigestFromStdIn {
 mod tests {
     use super::*;
     use crate::execute_with_terminal_state;
+    use crate::test_prelude::*;
 
     #[derive(Debug, Clone, Eq, PartialEq)]
     struct ProgramSetup {
@@ -73,7 +74,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn positive_test() {
         let test_setup = test_program();
 
@@ -96,7 +97,7 @@ mod tests {
         assert!(vm_end_state.jump_stack.is_empty());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn negative_test_expect_assertion_fail_due_to_bad_std_in() {
         let test_setup = test_program();
 

--- a/tasm-lib/src/verifier/stark_verify.rs
+++ b/tasm-lib/src/verifier/stark_verify.rs
@@ -1209,13 +1209,13 @@ pub mod tests {
     use crate::execute_test;
     use crate::maybe_write_debuggable_vm_state_to_disk;
     use crate::memory::FIRST_NON_DETERMINISTICALLY_INITIALIZED_MEMORY_ADDRESS;
-    use crate::memory::encode_to_memory;
     use crate::test_helpers::maybe_write_tvm_output_to_disk;
+    use crate::test_prelude::*;
     use crate::verifier::claim::shared::insert_claim_into_static_memory;
     use crate::verifier::master_table::air_constraint_evaluation::an_integral_but_profane_dynamic_memory_layout;
 
     #[ignore = "Used for debugging when comparing two versions of the verifier"]
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn verify_from_stored_proof_output() {
         use std::fs::File;
         let stark = File::open("stark.json").expect("stark file should open read only");
@@ -1253,7 +1253,7 @@ pub mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn fail_on_too_big_log2_padded_height() {
         let mut proof_stream = ProofStream::new();
         proof_stream.enqueue(ProofItem::Log2PaddedHeight(32));
@@ -1354,7 +1354,7 @@ pub mod tests {
         (final_tasm_state.cycle_count as usize, inner_padded_height)
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn different_fri_expansion_factors() {
         const FACTORIAL_ARGUMENT: u32 = 3;
 
@@ -1401,17 +1401,17 @@ pub mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn verify_tvm_proof_factorial_program_conventional_static_memlayout() {
         verify_tvm_proof_factorial_program_basic_properties(MemoryLayout::conventional_static());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn verify_tvm_proof_factorial_program_conventional_dynamic_memlayout() {
         verify_tvm_proof_factorial_program_basic_properties(MemoryLayout::conventional_dynamic());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn verify_tvm_proof_factorial_program_profane_dynamic_memlayout() {
         verify_tvm_proof_factorial_program_basic_properties(MemoryLayout::Dynamic(
             an_integral_but_profane_dynamic_memory_layout(),
@@ -1515,7 +1515,7 @@ pub mod tests {
         (nondeterminism, claim)
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn verify_two_proofs() {
         #[derive(Debug, Clone, BFieldCodec, TasmObject)]
         struct TwoProofs {
@@ -1653,15 +1653,14 @@ mod benches {
     use super::*;
     use crate::generate_full_profile;
     use crate::linker::execute_bench;
-    use crate::memory::encode_to_memory;
-    use crate::snippet_bencher::BenchmarkCase;
     use crate::snippet_bencher::NamedBenchmarkResult;
     use crate::snippet_bencher::write_benchmarks;
     use crate::test_helpers::prepend_program_with_stack_setup;
+    use crate::test_prelude::*;
     use crate::verifier::claim::shared::insert_claim_into_static_memory;
 
     #[ignore = "Used for profiling the verification of a proof stored on disk."]
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn profile_from_stored_proof_output() {
         use std::fs::File;
         let stark = File::open("stark.json").expect("stark file should open read only");
@@ -1701,7 +1700,7 @@ mod benches {
         println!("{profile}");
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark_small_default_stark_static_memory() {
         benchmark_verifier(
             3,
@@ -1717,7 +1716,7 @@ mod benches {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark_small_default_stark_dynamic_memory() {
         benchmark_verifier(
             3,
@@ -1734,7 +1733,7 @@ mod benches {
     }
 
     #[ignore = "Takes a fairly long time. Intended to find optimal FRI expansion factor."]
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn small_benchmark_different_fri_expansion_factors() {
         for log2_of_fri_expansion_factor in 1..=5 {
             let stark = Stark::new(160, log2_of_fri_expansion_factor);
@@ -1746,7 +1745,7 @@ mod benches {
 
     #[ignore = "Takes a very long time. Intended to find optimal FRI expansion factor. Make sure to run
        with `RUSTFLAGS=\"-C opt-level=3 -C debug-assertions=no\"`"]
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn big_benchmark_different_fri_expansion_factors() {
         let mem_layout = MemoryLayout::conventional_static();
         for log2_of_fri_expansion_factor in 2..=3 {
@@ -1759,7 +1758,7 @@ mod benches {
 
     #[ignore = "Intended to generate data about verifier table heights as a function of inner padded
        height. Make sure to run with `RUSTFLAGS=\"-C opt-level=3 -C debug-assertions=no\"`"]
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark_verification_as_a_function_of_inner_padded_height() {
         for (fact_arg, expected_inner_padded_height) in [
             (10, 1 << 8),

--- a/tasm-lib/src/verifier/stark_verify.rs
+++ b/tasm-lib/src/verifier/stark_verify.rs
@@ -1341,7 +1341,8 @@ pub mod tests {
             vec![],
             non_determinism,
             None,
-        );
+        )
+        .unwrap();
 
         let (aet, _public_output) = VM::trace_execution(
             inner_program,

--- a/tasm-lib/src/verifier/vm_proof_iter/dequeue_next_as.rs
+++ b/tasm-lib/src/verifier/vm_proof_iter/dequeue_next_as.rs
@@ -648,7 +648,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn disallow_too_big_dynamically_sized_proof_item() {
         let dequeue_next_as = DequeueNextAs::new(ProofItemVariant::MasterMainTableRows);
         let initial_state = initial_state_with_too_big_master_table_rows();
@@ -690,7 +690,7 @@ mod tests {
             .initial_state_from_proof_and_address(proof_stream.into(), proof_ptr)
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn disallow_trailing_zeros_in_xfe_poly_encoding() {
         let dequeue_next_as = DequeueNextAs::new(ProofItemVariant::FriPolynomial);
         let initial_state = initial_state_with_trailing_zeros_in_xfe_poly_encoding();
@@ -782,14 +782,14 @@ mod tests {
         dequeue_next_as.test_rust_equivalence(init_state);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn dequeueing_all_proof_items_individually_is_equivalent_in_rust_and_tasm() {
         for variant in ProofItemVariant::iter() {
             dequeueing_is_equivalent_in_rust_and_tasm_prop(variant);
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn dequeuing_as_suggested_element_is_equivalent_in_rust_and_tasm(seed: [u8; 32]) {
         let dequeue_next_as = DequeueNextAs::pseudorandom_new(seed);
         let initial_state = dequeue_next_as.pseudorandom_initial_state(seed, None);
@@ -881,7 +881,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn dequeue_two() {
         let proof_items = vec![ProofItemVariant::MerkleRoot, ProofItemVariant::MerkleRoot];
         let dequeue_multiple = TestHelperDequeueMultipleAs { proof_items };
@@ -889,7 +889,7 @@ mod tests {
         dequeue_multiple.test_rust_equivalence(initial_state);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn dequeue_multiple(#[strategy(arb())] proof_items: Vec<ProofItem>, seed: [u8; 32]) {
         let proof_items = proof_items.into_iter().map(|i| i.into()).collect_vec();
         let dequeue_multiple = TestHelperDequeueMultipleAs { proof_items };

--- a/tasm-lib/src/verifier/vm_proof_iter/dequeue_next_as.rs
+++ b/tasm-lib/src/verifier/vm_proof_iter/dequeue_next_as.rs
@@ -399,13 +399,14 @@ mod tests {
     }
 
     impl RustShadowForDequeueNextAs<'_> {
-        fn execute(&mut self) -> Vec<BFieldElement> {
-            self.assert_correct_discriminant();
+        fn execute(&mut self) -> Result<Vec<BFieldElement>, RustShadowError> {
+            self.assert_correct_discriminant()?;
             self.maybe_alter_fiat_shamir_heuristic_with_proof_item();
             self.update_stack_using_current_proof_item();
             self.update_proof_item_iter();
             self.update_current_item_count();
-            self.public_output()
+
+            Ok(self.public_output())
         }
 
         fn current_proof_item_list_element_size_pointer(&self) -> BFieldElement {
@@ -460,9 +461,13 @@ mod tests {
             }
         }
 
-        fn assert_correct_discriminant(&self) {
+        fn assert_correct_discriminant(&self) -> Result<(), RustShadowError> {
             let expected_discriminant = self.dequeue_next_as.proof_item.bfield_codec_discriminant();
-            assert_eq!(expected_discriminant, self.discriminant().value() as usize);
+            if expected_discriminant != self.discriminant().value() as usize {
+                return Err(RustShadowError::Other);
+            };
+
+            Ok(())
         }
 
         fn proof_item(&self) -> ProofItem {
@@ -512,13 +517,17 @@ mod tests {
             _: &NonDeterminism,
             _: &[BFieldElement],
             sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
+            let Some(sponge) = sponge.as_mut() else {
+                return Err(RustShadowError::SpongeUninitialized);
+            };
+
             RustShadowForDequeueNextAs {
                 dequeue_next_as: *self,
-                proof_iter_pointer: stack.pop().unwrap(),
+                proof_iter_pointer: stack.pop().ok_or(RustShadowError::StackUnderflow)?,
                 stack,
                 memory,
-                sponge: sponge.as_mut().unwrap(),
+                sponge,
             }
             .execute()
         }
@@ -660,17 +669,15 @@ mod tests {
             None,
         );
 
-        let rust_result = std::panic::catch_unwind(|| {
-            let mut stack = initial_state.stack.clone();
-            let mut memory = initial_state.nondeterminism.ram.clone();
-            dequeue_next_as.rust_shadow(
-                &mut stack,
-                &mut memory,
-                &NonDeterminism::default(),
-                &[],
-                &mut None,
-            );
-        });
+        let mut stack = initial_state.stack.clone();
+        let mut memory = initial_state.nondeterminism.ram.clone();
+        let rust_result = dequeue_next_as.rust_shadow(
+            &mut stack,
+            &mut memory,
+            &NonDeterminism::default(),
+            &[],
+            &mut None,
+        );
 
         assert!(
             rust_result.is_err() && tvm_result.is_err(),
@@ -703,17 +710,15 @@ mod tests {
             None,
         );
 
-        let rust_result = std::panic::catch_unwind(|| {
-            let mut stack = initial_state.stack.clone();
-            let mut memory = initial_state.nondeterminism.ram.clone();
-            dequeue_next_as.rust_shadow(
-                &mut stack,
-                &mut memory,
-                &NonDeterminism::default(),
-                &[],
-                &mut None,
-            );
-        });
+        let mut stack = initial_state.stack.clone();
+        let mut memory = initial_state.nondeterminism.ram.clone();
+        let rust_result = dequeue_next_as.rust_shadow(
+            &mut stack,
+            &mut memory,
+            &NonDeterminism::default(),
+            &[],
+            &mut None,
+        );
 
         assert!(
             rust_result.is_err() && tvm_result.is_err(),
@@ -839,15 +844,19 @@ mod tests {
             non_determinism: &NonDeterminism,
             std_in: &[BFieldElement],
             sponge: &mut Option<Tip5>,
-        ) -> Vec<BFieldElement> {
-            let &proof_iter_pointer = stack.last().unwrap();
+        ) -> Result<Vec<BFieldElement>, RustShadowError> {
+            let proof_iter_pointer = stack
+                .last()
+                .copied()
+                .ok_or(RustShadowError::StackUnderflow)?;
             for &proof_item in &self.proof_items {
                 let dequeue_next_as = DequeueNextAs { proof_item };
                 stack.push(proof_iter_pointer);
-                dequeue_next_as.rust_shadow(stack, memory, non_determinism, std_in, sponge);
-                stack.pop().unwrap();
+                dequeue_next_as.rust_shadow(stack, memory, non_determinism, std_in, sponge)?;
+                stack.pop().ok_or(RustShadowError::StackUnderflow)?;
             }
-            vec![]
+
+            Ok(Vec::new())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/verifier/vm_proof_iter/drop.rs
+++ b/tasm-lib/src/verifier/vm_proof_iter/drop.rs
@@ -72,12 +72,12 @@ mod tests {
     use crate::verifier::vm_proof_iter::dequeue_next_as::DequeueNextAs;
     use crate::verifier::vm_proof_iter::shared::vm_proof_iter_struct::VmProofIter;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn rust_shadow() {
         ShadowedAccessor::new(Drop).test();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn negative_test_proof_len_mismatch() {
         let proof_ptr = bfe!(450);
         let proof_len = 10_000u32;
@@ -97,7 +97,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn negative_test_proof_item_count_mismatch() {
         let proof_ptr = bfe!(450);
         let proof_len = 10_000u32;
@@ -193,7 +193,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedAccessor::new(Drop).bench();
     }

--- a/tasm-lib/src/verifier/vm_proof_iter/drop.rs
+++ b/tasm-lib/src/verifier/vm_proof_iter/drop.rs
@@ -133,23 +133,21 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let vm_proof_iter_ptr = stack.pop().unwrap();
-            let vm_proof_iter =
-                *VmProofIter::decode_from_memory(memory, vm_proof_iter_ptr).unwrap();
-            assert_eq!(
-                vm_proof_iter.current_item_count,
-                vm_proof_iter.total_item_count
-            );
+        ) -> Result<(), RustShadowError> {
+            let vm_proof_iter_ptr = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let vm_proof_iter = *VmProofIter::decode_from_memory(memory, vm_proof_iter_ptr)
+                .map_err(|_| RustShadowError::DecodingError)?;
+            if vm_proof_iter.current_item_count != vm_proof_iter.total_item_count {
+                return Err(RustShadowError::InvalidProof);
+            }
 
-            assert_eq!(
-                vm_proof_iter.proof_start_pointer + bfe!(vm_proof_iter.proof_length + 1),
-                vm_proof_iter.current_item_pointer,
-                "{} + {} and {} must match",
-                vm_proof_iter.proof_start_pointer,
-                vm_proof_iter.proof_length,
-                vm_proof_iter.current_item_pointer
-            );
+            if vm_proof_iter.proof_start_pointer + bfe!(vm_proof_iter.proof_length + 1)
+                != vm_proof_iter.current_item_pointer
+            {
+                return Err(RustShadowError::InvalidProof);
+            }
+
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/verifier/vm_proof_iter/new.rs
+++ b/tasm-lib/src/verifier/vm_proof_iter/new.rs
@@ -177,14 +177,16 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let pointer_to_proof = stack.pop().unwrap();
-            let proof = *Proof::decode_from_memory(memory, pointer_to_proof).unwrap();
+        ) -> Result<(), RustShadowError> {
+            let pointer_to_proof = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let proof = *Proof::decode_from_memory(memory, pointer_to_proof)
+                .map_err(|_| RustShadowError::DecodingError)?;
             let pointer_to_vm_proof_iter =
                 rust_shadowing_helper_functions::dyn_malloc::dynamic_allocator(memory);
             let vm_proof_iter = VmProofIter::new(pointer_to_proof, &proof);
             encode_to_memory(memory, pointer_to_vm_proof_iter, &vm_proof_iter);
             stack.push(pointer_to_vm_proof_iter);
+            Ok(())
         }
 
         fn pseudorandom_initial_state(

--- a/tasm-lib/src/verifier/vm_proof_iter/new.rs
+++ b/tasm-lib/src/verifier/vm_proof_iter/new.rs
@@ -145,7 +145,7 @@ mod tests {
     use crate::test_prelude::*;
     use crate::verifier::vm_proof_iter::shared::vm_proof_iter_struct::VmProofIter;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn vm_proof_iter_new_pbt() {
         ShadowedFunction::new(New).test()
     }

--- a/tasm-lib/src/verifier/xfe_ntt.rs
+++ b/tasm-lib/src/verifier/xfe_ntt.rs
@@ -478,15 +478,16 @@ mod tests {
             &self,
             stack: &mut Vec<BFieldElement>,
             memory: &mut HashMap<BFieldElement, BFieldElement>,
-        ) {
-            let _root_of_unity = stack.pop().unwrap();
-            let input_pointer = stack.pop().unwrap();
+        ) -> Result<(), RustShadowError> {
+            let _root_of_unity = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
+            let input_pointer = stack.pop().ok_or(RustShadowError::StackUnderflow)?;
 
-            let mut vector =
-                *Vec::<XFieldElement>::decode_from_memory(memory, input_pointer).unwrap();
+            let mut vector = *Vec::<XFieldElement>::decode_from_memory(memory, input_pointer)
+                .map_err(|_| RustShadowError::DecodingError)?;
             ntt(&mut vector);
 
             encode_to_memory(memory, input_pointer, &vector);
+            Ok(())
         }
 
         fn pseudorandom_initial_state(
@@ -534,7 +535,7 @@ mod tests {
             let rust = rust_final_state(&function, &stack, &stdin, &nondeterminism, &None);
 
             // run tvm
-            let tasm = tasm_final_state(&function, &stack, &stdin, nondeterminism, &None);
+            let tasm = tasm_final_state(&function, &stack, &stdin, nondeterminism, &None).unwrap();
 
             assert_eq!(
                 rust.public_output, tasm.public_output,

--- a/tasm-lib/src/verifier/xfe_ntt.rs
+++ b/tasm-lib/src/verifier/xfe_ntt.rs
@@ -514,7 +514,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn test() {
         let function = ShadowedFunction::new(XfeNtt);
         let num_states = 5;
@@ -577,7 +577,7 @@ mod benches {
     use super::*;
     use crate::test_prelude::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn benchmark() {
         ShadowedFunction::new(XfeNtt).bench();
     }


### PR DESCRIPTION
In particular, `tasm-lib` can now be compiled to the `wasm32-unknown-unknown` target. Continuous integration checks for future regressions by testing through `wasm-pack test`.

In order to facilitate testing, snippet sign-offs are ignored on the `wasm32` architecture; apparently, there we run into portability issues around hashing.
Due to a lack of file system access, benchmark results are not persisted on `wasm32` targets.

The crate `web-time` is taken on as a new dependency to facilitate this upgrade. On architectures other than `wasm32`, this crate uses `std::time` directly, resulting in no change at all.

This PR includes a big refactor that, hopefully, has positive impact downstream: snippet's rust-shadow implementations and fallible rust-shadow helpers now return `Result<_, RustShadowError>` instead of whatever `_` had been. This allows equivalence testing of snippets and their rust-shadow even in error cases and, crucially, without the need to rely on `catch_unwind`.